### PR TITLE
fix: build

### DIFF
--- a/UlasKelas/urls.py
+++ b/UlasKelas/urls.py
@@ -31,7 +31,7 @@ urlpatterns = [
     path('health-check', views.health_check),
     path('login/', views.login),
     path('api/', include(("main.urls", "api"), namespace="v1")),
-    path('api/v1/', include(("main.urls", "api"), namespace="v1")),
+    path('api/v1/', include(("main.urls", "api"), namespace="v1_explicit")),
     path('api/v2/', include(("main.urls", "api"), namespace="v2")),
     path('api-auth-token/', views_token.obtain_auth_token),
     path('token/', views.token, name='token'),


### PR DESCRIPTION
Change duplicate v1 namespace

from
```
path('api/', include(("main.urls", "api"), namespace="v1")),
path('api/v1/', include(("main.urls", "api"), namespace="v1")),
```
to
```
path('api/', include(("main.urls", "api"), namespace="v1")),
path('api/v1/', include(("main.urls", "api"), namespace="v1_explicit")),
```

