### PR TITLE
Feat/siak irs import

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,32 @@ Run the all-program command weekly from the deployment scheduler. A failed
 program is reported at the end without preventing the remaining programs from
 being synchronized.
 
+### Import an active SIAK IRS locally
+
+This proof of concept runs only as a local management command. Install the
+temporary browser used by Playwright:
+
+```bash
+pip install -r requirements-siak.txt
+python -m playwright install chromium
+```
+
+Run a preview for a local Teman Kuliah profile and calculator semester:
+
+```bash
+python manage.py import_siak_irs \
+    --username example.username \
+    --semester 1 \
+    --dry-run
+```
+
+The command opens an isolated browser. Complete the SIAK challenge and login,
+open the active IRS page, then return to the terminal. Remove `--dry-run` to
+preview and confirm the database import in the same browser session. Existing
+calculator courses are skipped, and SIAK codes missing from the local catalog
+are reported. The command does not save SIAK credentials, cookies, page HTML,
+or browser storage.
+
 
 -------
 

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Run the all-program command weekly from the deployment scheduler. A failed
 program is reported at the end without preventing the remaining programs from
 being synchronized.
 
-### Import an active SIAK IRS locally
+### Import the latest SIAK academic-history period locally
 
 This proof of concept runs only as a local management command. Install the
 temporary browser used by Playwright:
@@ -146,12 +146,15 @@ python manage.py import_siak_irs \
     --dry-run
 ```
 
-The command opens an isolated browser. Complete the SIAK challenge and login,
-open the active IRS page, then return to the terminal. Remove `--dry-run` to
-preview and confirm the database import in the same browser session. Existing
-calculator courses are skipped, and SIAK codes missing from the local catalog
-are reported. The command does not save SIAK credentials, cookies, page HTML,
-or browser storage.
+The command opens an isolated browser at the SIAK academic-history page.
+Complete the SIAK challenge and login; no terminal confirmation is needed.
+After authentication, the command returns to the history page automatically and
+previews only the latest academic period that contains courses. Remove
+`--dry-run` to confirm the database import in the same browser session.
+Existing calculator courses are skipped, and SIAK codes missing from the local
+catalog are reported. The command does not save SIAK credentials, cookies, page
+HTML, or browser storage. Use `--login-timeout` to override the default
+five-minute login window.
 
 
 -------

--- a/main/integrations/__init__.py
+++ b/main/integrations/__init__.py
@@ -1,0 +1,1 @@
+"""Integrations with external academic systems."""

--- a/main/integrations/siak_irs.py
+++ b/main/integrations/siak_irs.py
@@ -1,0 +1,228 @@
+import re
+import unicodedata
+
+from django.db import transaction
+
+from main.models import Calculator, Course, CourseSemester, UserGPA
+from main.utils import (
+    add_course_to_semester,
+    add_semester_gpa,
+    check_notexist_and_create_user_cumulative_gpa,
+)
+
+
+class IRSParseError(ValueError):
+    """Raised when the active IRS table cannot be recognized."""
+
+
+HEADER_ALIASES = {
+    "code": {
+        "code",
+        "course code",
+        "kode",
+        "kode mata kuliah",
+        "kode matakuliah",
+        "kode mk",
+    },
+    "name": {
+        "course",
+        "course name",
+        "mata kuliah",
+        "matakuliah",
+        "nama",
+        "nama mata kuliah",
+        "nama matakuliah",
+        "nama mk",
+    },
+    "credits": {
+        "credit",
+        "credits",
+        "credit units",
+        "jumlah sks",
+        "sks",
+    },
+}
+
+
+def normalize_header(value):
+    value = unicodedata.normalize("NFKC", str(value or "")).casefold()
+    value = re.sub(r"[^a-z0-9]+", " ", value)
+    return " ".join(value.split())
+
+
+def normalize_course_code(value):
+    value = unicodedata.normalize("NFKC", str(value or "")).upper()
+    return re.sub(r"\s+", "", value)
+
+
+def _column_indexes(headers):
+    normalized = [normalize_header(header) for header in headers]
+    indexes = {}
+    for field, aliases in HEADER_ALIASES.items():
+        for index, header in enumerate(normalized):
+            if header in aliases:
+                indexes[field] = index
+                break
+    return indexes
+
+
+def parse_irs_tables(tables):
+    """
+    Parse browser-extracted tables and return unique active-IRS courses.
+
+    ``tables`` is a list of dictionaries containing ``headers`` and ``rows``.
+    Keeping this parser independent of Playwright makes it safe to unit test
+    without a live SIAK session.
+    """
+    candidates = []
+    observed_headers = []
+    for table in tables:
+        headers = table.get("headers") or []
+        observed_headers.append([normalize_header(value) for value in headers])
+        indexes = _column_indexes(headers)
+        if {"code", "name", "credits"}.issubset(indexes):
+            candidates.append((table, indexes))
+
+    if not candidates:
+        readable_headers = "; ".join(
+            ", ".join(headers) for headers in observed_headers if headers
+        )
+        detail = (
+            " Observed headers: {}.".format(readable_headers)
+            if readable_headers
+            else ""
+        )
+        raise IRSParseError(
+            "Could not find an IRS table with course code, name, and SKS columns."
+            + detail
+        )
+
+    parsed_candidates = [
+        _parse_candidate(table, indexes) for table, indexes in candidates
+    ]
+    courses = max(parsed_candidates, key=len)
+    if not courses:
+        raise IRSParseError("The recognized IRS table does not contain valid courses.")
+    return courses
+
+
+def _parse_candidate(table, indexes):
+    courses = []
+    seen_codes = set()
+    maximum_index = max(indexes.values())
+    for row in table.get("rows") or []:
+        if len(row) <= maximum_index:
+            continue
+        code = normalize_course_code(row[indexes["code"]])
+        name = " ".join(str(row[indexes["name"]] or "").split())
+        credits_text = str(row[indexes["credits"]] or "").strip()
+        credits_match = re.search(r"\d+", credits_text)
+        if not code or not name or credits_match is None or code in seen_codes:
+            continue
+        seen_codes.add(code)
+        courses.append(
+            {
+                "code": code,
+                "name": name,
+                "credits": int(credits_match.group()),
+            }
+        )
+    return courses
+
+
+def collect_page_tables(page):
+    """Extract table text from the current page without persisting its DOM."""
+    return page.evaluate(
+        """
+        () => Array.from(document.querySelectorAll("table")).map((table) => {
+          const allRows = Array.from(table.querySelectorAll("tr"));
+          if (allRows.length === 0) {
+            return {headers: [], rows: []};
+          }
+
+          let headers = Array.from(
+            table.querySelectorAll("thead th")
+          ).map((cell) => cell.innerText.trim());
+          let bodyRows = Array.from(table.querySelectorAll("tbody tr"));
+
+          if (headers.length === 0) {
+            headers = Array.from(
+              allRows[0].querySelectorAll("th, td")
+            ).map((cell) => cell.innerText.trim());
+            bodyRows = allRows.slice(1);
+          }
+
+          return {
+            headers,
+            rows: bodyRows.map((row) =>
+              Array.from(row.querySelectorAll("th, td")).map(
+                (cell) => cell.innerText.trim()
+              )
+            ),
+          };
+        })
+        """
+    )
+
+
+def resolve_courses(scraped_courses):
+    """Resolve scraped codes to local courses and report unmatched entries."""
+    resolved = []
+    unmatched = []
+    seen_ids = set()
+    for scraped_course in scraped_courses:
+        code = normalize_course_code(scraped_course["code"])
+        course = (
+            Course.objects.filter(code__iexact=code)
+            .order_by("-curriculum", "id")
+            .first()
+        )
+        if course is None:
+            unmatched.append(scraped_course)
+            continue
+        if course.id not in seen_ids:
+            seen_ids.add(course.id)
+            resolved.append(course)
+    return resolved, unmatched
+
+
+@transaction.atomic
+def import_courses(profile, given_semester, courses):
+    """Add resolved courses to one calculator semester atomically."""
+    cumulative_gpa = check_notexist_and_create_user_cumulative_gpa(profile)
+    semester, semester_created = UserGPA.objects.get_or_create(
+        userCumulativeGPA=cumulative_gpa,
+        given_semester=str(given_semester),
+    )
+    existing_ids = set(
+        CourseSemester.objects.filter(
+            semester=semester, course_id__in=[course.id for course in courses]
+        ).values_list("course_id", flat=True)
+    )
+    inserted = []
+    duplicates = []
+    for course in courses:
+        if course.id in existing_ids:
+            duplicates.append(course)
+            continue
+
+        calculator = Calculator.objects.create(user=profile, course=course)
+        CourseSemester.objects.create(
+            semester=semester,
+            course=course,
+            calculator=calculator,
+        )
+        add_course_to_semester(semester=semester, sks=course.sks)
+        add_semester_gpa(
+            user_cumulative_gpa=cumulative_gpa,
+            total_sks=course.sks,
+            semester_gpa=0,
+        )
+        inserted.append(course)
+
+    return {
+        "semester": semester,
+        "semester_created": semester_created,
+        "inserted": inserted,
+        "duplicates": duplicates,
+    }

--- a/main/integrations/siak_irs.py
+++ b/main/integrations/siak_irs.py
@@ -12,7 +12,7 @@ from main.utils import (
 
 
 class IRSParseError(ValueError):
-    """Raised when the active IRS table cannot be recognized."""
+    """Raised when the SIAK academic-history table cannot be recognized."""
 
 
 HEADER_ALIASES = {
@@ -41,6 +41,16 @@ HEADER_ALIASES = {
         "jumlah sks",
         "sks",
     },
+    "period": {
+        "academic period",
+        "academic term",
+        "periode",
+        "periode akademik",
+        "semester",
+        "tahun akademik",
+        "tahun ajaran",
+        "term",
+    },
 }
 
 
@@ -66,24 +76,43 @@ def _column_indexes(headers):
     return indexes
 
 
-def parse_irs_tables(tables):
+def parse_latest_history(tables):
     """
-    Parse browser-extracted tables and return unique active-IRS courses.
+    Return the latest non-empty academic period from browser-extracted tables.
 
     ``tables`` is a list of dictionaries containing ``headers`` and ``rows``.
     Keeping this parser independent of Playwright makes it safe to unit test
     without a live SIAK session.
     """
-    candidates = []
+    courses_by_period = {}
     observed_headers = []
     for table in tables:
         headers = table.get("headers") or []
         observed_headers.append([normalize_header(value) for value in headers])
         indexes = _column_indexes(headers)
-        if {"code", "name", "credits"}.issubset(indexes):
-            candidates.append((table, indexes))
+        if not {"code", "name", "credits"}.issubset(indexes):
+            continue
 
-    if not candidates:
+        if "period" in indexes:
+            for period_label, courses in _parse_period_column(table, indexes).items():
+                courses_by_period.setdefault(period_label, []).extend(courses)
+            continue
+
+        if table.get("row_periods"):
+            for period_label, courses in _parse_row_periods(table, indexes).items():
+                courses_by_period.setdefault(period_label, []).extend(courses)
+            continue
+
+        period_label = _normalize_period_label(table.get("period_label"))
+        if period_label is not None:
+            courses_by_period.setdefault(period_label, []).extend(
+                _parse_candidate(table, indexes)
+            )
+
+    if not any(
+        {"code", "name", "credits"}.issubset(_column_indexes(table.get("headers") or []))
+        for table in tables
+    ):
         readable_headers = "; ".join(
             ", ".join(headers) for headers in observed_headers if headers
         )
@@ -97,37 +126,120 @@ def parse_irs_tables(tables):
             + detail
         )
 
-    parsed_candidates = [
-        _parse_candidate(table, indexes) for table, indexes in candidates
-    ]
-    courses = max(parsed_candidates, key=len)
-    if not courses:
-        raise IRSParseError("The recognized IRS table does not contain valid courses.")
-    return courses
+    non_empty_periods = {
+        label: _deduplicate_courses(courses)
+        for label, courses in courses_by_period.items()
+        if courses
+    }
+    if not non_empty_periods:
+        raise IRSParseError(
+            "Course tables were found, but their academic periods could not be "
+            "recognized or did not contain valid courses."
+        )
+
+    try:
+        period_label = max(non_empty_periods, key=_period_sort_key)
+    except ValueError as exc:
+        raise IRSParseError(
+            "Academic period labels were found but could not be ordered."
+        ) from exc
+    return {
+        "period": period_label,
+        "courses": non_empty_periods[period_label],
+    }
 
 
-def _parse_candidate(table, indexes):
-    courses = []
-    seen_codes = set()
+def _parse_period_column(table, indexes):
+    courses_by_period = {}
     maximum_index = max(indexes.values())
     for row in table.get("rows") or []:
         if len(row) <= maximum_index:
             continue
-        code = normalize_course_code(row[indexes["code"]])
-        name = " ".join(str(row[indexes["name"]] or "").split())
-        credits_text = str(row[indexes["credits"]] or "").strip()
-        credits_match = re.search(r"\d+", credits_text)
-        if not code or not name or credits_match is None or code in seen_codes:
+        period_label = _normalize_period_label(row[indexes["period"]])
+        course = _parse_course_row(row, indexes)
+        if period_label is not None and course is not None:
+            courses_by_period.setdefault(period_label, []).append(course)
+    return courses_by_period
+
+
+def _parse_row_periods(table, indexes):
+    courses_by_period = {}
+    row_periods = table.get("row_periods") or []
+    maximum_index = max(indexes.values())
+    for row_index, row in enumerate(table.get("rows") or []):
+        if len(row) <= maximum_index or row_index >= len(row_periods):
             continue
-        seen_codes.add(code)
-        courses.append(
-            {
-                "code": code,
-                "name": name,
-                "credits": int(credits_match.group()),
-            }
-        )
-    return courses
+        period_label = _normalize_period_label(row_periods[row_index])
+        course = _parse_course_row(row, indexes)
+        if period_label is not None and course is not None:
+            courses_by_period.setdefault(period_label, []).append(course)
+    return courses_by_period
+
+
+def _parse_candidate(table, indexes):
+    courses = []
+    maximum_index = max(indexes.values())
+    for row in table.get("rows") or []:
+        if len(row) <= maximum_index:
+            continue
+        course = _parse_course_row(row, indexes)
+        if course is not None:
+            courses.append(course)
+    return _deduplicate_courses(courses)
+
+
+def _parse_course_row(row, indexes):
+    code = normalize_course_code(row[indexes["code"]])
+    name = " ".join(str(row[indexes["name"]] or "").split())
+    credits_text = str(row[indexes["credits"]] or "").strip()
+    credits_match = re.search(r"\d+", credits_text)
+    if not code or not name or credits_match is None:
+        return None
+    return {
+        "code": code,
+        "name": name,
+        "credits": int(credits_match.group()),
+    }
+
+
+def _deduplicate_courses(courses):
+    unique_courses = []
+    seen_codes = set()
+    for course in courses:
+        if course["code"] not in seen_codes:
+            seen_codes.add(course["code"])
+            unique_courses.append(course)
+    return unique_courses
+
+
+def _normalize_period_label(value):
+    label = " ".join(str(value or "").split())
+    return label or None
+
+
+def _period_sort_key(label):
+    normalized = normalize_header(label)
+    year_range = re.search(r"\b(20\d{2})\s+(20\d{2})\b", normalized)
+    if year_range:
+        start_year = int(year_range.group(1))
+    else:
+        compact_period = re.search(r"\b(20\d{2})\s+([123])\b", normalized)
+        if compact_period is None:
+            raise ValueError("Unrecognized academic period: {}".format(label))
+        start_year = int(compact_period.group(1))
+
+    if re.search(r"\b(pendek|short|antara|term 3|semester 3)\b", normalized):
+        term_rank = 3
+    elif re.search(r"\b(genap|even|term 2|semester 2)\b", normalized):
+        term_rank = 2
+    elif re.search(r"\b(ganjil|gasal|odd|term 1|semester 1)\b", normalized):
+        term_rank = 1
+    else:
+        trailing_term = re.search(r"\b([123])\s*$", normalized)
+        if trailing_term is None:
+            raise ValueError("Unrecognized academic term: {}".format(label))
+        term_rank = int(trailing_term.group(1))
+    return start_year, term_rank
 
 
 def collect_page_tables(page):
@@ -135,30 +247,69 @@ def collect_page_tables(page):
     return page.evaluate(
         """
         () => Array.from(document.querySelectorAll("table")).map((table) => {
-          const allRows = Array.from(table.querySelectorAll("tr"));
+          const allRows = Array.from(table.querySelectorAll("tr")).filter(
+            (row) => row.closest("table") === table
+          );
           if (allRows.length === 0) {
             return {headers: [], rows: []};
           }
 
           let headers = Array.from(
             table.querySelectorAll("thead th")
+          ).filter(
+            (cell) => cell.closest("table") === table
           ).map((cell) => cell.innerText.trim());
-          let bodyRows = Array.from(table.querySelectorAll("tbody tr"));
+          let bodyRows = Array.from(table.querySelectorAll("tbody tr")).filter(
+            (row) => row.closest("table") === table
+          );
 
           if (headers.length === 0) {
-            headers = Array.from(
-              allRows[0].querySelectorAll("th, td")
+            headers = Array.from(allRows[0].children).filter(
+              (cell) => ["TH", "TD"].includes(cell.tagName)
             ).map((cell) => cell.innerText.trim());
             bodyRows = allRows.slice(1);
           }
 
+          const caption = table.querySelector("caption");
+          let periodLabel = caption ? caption.innerText.trim() : "";
+          if (!periodLabel) {
+            let sibling = table.previousElementSibling;
+            for (let index = 0; sibling && index < 5; index += 1) {
+              const text = sibling.innerText ? sibling.innerText.trim() : "";
+              if (text && /20\\d{2}/.test(text)) {
+                periodLabel = text;
+                break;
+              }
+              sibling = sibling.previousElementSibling;
+            }
+          }
+
+          const rows = [];
+          const rowPeriods = [];
+          let currentPeriod = periodLabel;
+          bodyRows.forEach((row) => {
+            const cells = Array.from(row.children).filter(
+              (cell) => ["TH", "TD"].includes(cell.tagName)
+            );
+            const values = cells.map((cell) => cell.innerText.trim());
+            if (
+              values.length === 1 &&
+              /Tahun Ajaran\\s+20\\d{2}\\s*\\/\\s*20\\d{2}\\s+Term\\s+[123]/i.test(
+                values[0]
+              )
+            ) {
+              currentPeriod = values[0];
+              return;
+            }
+            rows.push(values);
+            rowPeriods.push(currentPeriod);
+          });
+
           return {
             headers,
-            rows: bodyRows.map((row) =>
-              Array.from(row.querySelectorAll("th, td")).map(
-                (cell) => cell.innerText.trim()
-              )
-            ),
+            period_label: periodLabel,
+            row_periods: rowPeriods,
+            rows,
           };
         })
         """

--- a/main/management/commands/import_siak_irs.py
+++ b/main/management/commands/import_siak_irs.py
@@ -1,0 +1,150 @@
+from django.core.management.base import BaseCommand, CommandError
+
+from main.integrations.siak_irs import (
+    IRSParseError,
+    collect_page_tables,
+    import_courses,
+    parse_irs_tables,
+    resolve_courses,
+)
+from main.models import CourseSemester, Profile
+
+
+DEFAULT_SIAK_URL = "https://academic.ui.ac.id/"
+
+
+class Command(BaseCommand):
+    help = (
+        "Open a temporary browser session and import the active SIAK IRS into "
+        "a local calculator semester."
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument("--username", required=True)
+        parser.add_argument("--semester", required=True)
+        parser.add_argument("--siak-url", default=DEFAULT_SIAK_URL)
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Show the import preview without changing the database.",
+        )
+        parser.add_argument(
+            "--yes",
+            action="store_true",
+            help="Apply without the final interactive confirmation.",
+        )
+
+    def handle(self, *args, **options):
+        profile = Profile.objects.filter(
+            username__iexact=options["username"]
+        ).first()
+        if profile is None:
+            raise CommandError(
+                "Profile with username={} was not found.".format(options["username"])
+            )
+
+        scraped_courses = self._scrape(options["siak_url"])
+        resolved, unmatched = resolve_courses(scraped_courses)
+        existing_codes = set(
+            CourseSemester.objects.filter(
+                semester__userCumulativeGPA__user=profile,
+                semester__given_semester=str(options["semester"]),
+                course__in=resolved,
+            ).values_list("course__code", flat=True)
+        )
+
+        self._print_preview(
+            profile=profile,
+            semester=options["semester"],
+            resolved=resolved,
+            unmatched=unmatched,
+            existing_codes=existing_codes,
+        )
+        if options["dry_run"]:
+            self.stdout.write(self.style.WARNING("Dry run: no data was changed."))
+            return
+        if not resolved:
+            raise CommandError(
+                "None of the SIAK course codes exist in the local course catalog."
+            )
+
+        if not options["yes"]:
+            answer = input("Import these courses into the local database? [y/N] ")
+            if answer.strip().casefold() not in {"y", "yes"}:
+                self.stdout.write(self.style.WARNING("Import cancelled."))
+                return
+
+        result = import_courses(profile, options["semester"], resolved)
+        self.stdout.write(
+            self.style.SUCCESS(
+                "Import complete: {} inserted, {} already present, {} unmatched.".format(
+                    len(result["inserted"]),
+                    len(result["duplicates"]),
+                    len(unmatched),
+                )
+            )
+        )
+
+    def _scrape(self, siak_url):
+        try:
+            from playwright.sync_api import Error as PlaywrightError
+            from playwright.sync_api import sync_playwright
+        except ImportError as exc:
+            raise CommandError(
+                "Playwright is not installed. Install dependencies and run "
+                "`python -m playwright install chromium`."
+            ) from exc
+
+        try:
+            with sync_playwright() as playwright:
+                browser = playwright.chromium.launch(headless=False)
+                context = browser.new_context()
+                try:
+                    page = context.new_page()
+                    page.goto(siak_url, wait_until="domcontentloaded")
+                    self.stdout.write(
+                        "Complete the SIAK challenge/login, open the active IRS "
+                        "page, then return here."
+                    )
+                    input("Press Enter when the IRS table is visible... ")
+                    tables = []
+                    for frame in list(page.frames):
+                        try:
+                            tables.extend(collect_page_tables(frame))
+                        except PlaywrightError as exc:
+                            if frame.is_detached() or "Frame was detached" in str(exc):
+                                continue
+                            raise
+                    return parse_irs_tables(tables)
+                finally:
+                    context.close()
+                    browser.close()
+        except IRSParseError as exc:
+            raise CommandError(str(exc)) from exc
+        except PlaywrightError as exc:
+            raise CommandError("SIAK browser session failed: {}".format(exc)) from exc
+
+    def _print_preview(
+        self, profile, semester, resolved, unmatched, existing_codes
+    ):
+        self.stdout.write(
+            "Target: {} ({}) — semester {}".format(
+                profile.name, profile.username, semester
+            )
+        )
+        self.stdout.write("Recognized local courses:")
+        for course in resolved:
+            marker = " [already present]" if course.code in existing_codes else ""
+            self.stdout.write(
+                "  {} — {} ({} SKS){}".format(
+                    course.code, course.name, course.sks, marker
+                )
+            )
+        if unmatched:
+            self.stdout.write(self.style.WARNING("Unmatched SIAK courses:"))
+            for course in unmatched:
+                self.stdout.write(
+                    "  {} — {} ({} SKS)".format(
+                        course["code"], course["name"], course["credits"]
+                    )
+                )

--- a/main/management/commands/import_siak_irs.py
+++ b/main/management/commands/import_siak_irs.py
@@ -4,25 +4,41 @@ from main.integrations.siak_irs import (
     IRSParseError,
     collect_page_tables,
     import_courses,
-    parse_irs_tables,
+    parse_latest_history,
     resolve_courses,
 )
 from main.models import CourseSemester, Profile
 
 
-DEFAULT_SIAK_URL = "https://academic.ui.ac.id/"
+DEFAULT_HISTORY_URL = "https://academic.ui.ac.id/main/Academic/HistoryByTerm"
+AUTHENTICATED_MARKER = (
+    "() => Array.from(document.querySelectorAll('a')).some((link) => "
+    "/\\/Authentication\\/Logout/i.test(link.getAttribute('href') || '') || "
+    "link.textContent.trim().toLowerCase() === 'logout')"
+)
 
 
 class Command(BaseCommand):
     help = (
-        "Open a temporary browser session and import the active SIAK IRS into "
-        "a local calculator semester."
+        "Open a temporary browser session and import the latest non-empty SIAK "
+        "academic-history period into a local calculator semester."
     )
 
     def add_arguments(self, parser):
         parser.add_argument("--username", required=True)
         parser.add_argument("--semester", required=True)
-        parser.add_argument("--siak-url", default=DEFAULT_SIAK_URL)
+        parser.add_argument(
+            "--history-url",
+            "--siak-url",
+            dest="history_url",
+            default=DEFAULT_HISTORY_URL,
+        )
+        parser.add_argument(
+            "--login-timeout",
+            type=int,
+            default=300,
+            help="Seconds to wait for the interactive SIAK login.",
+        )
         parser.add_argument(
             "--dry-run",
             action="store_true",
@@ -42,8 +58,13 @@ class Command(BaseCommand):
             raise CommandError(
                 "Profile with username={} was not found.".format(options["username"])
             )
+        if options["login_timeout"] <= 0:
+            raise CommandError("login-timeout must be greater than zero.")
 
-        scraped_courses = self._scrape(options["siak_url"])
+        scraped_history = self._scrape(
+            options["history_url"], options["login_timeout"]
+        )
+        scraped_courses = scraped_history["courses"]
         resolved, unmatched = resolve_courses(scraped_courses)
         existing_codes = set(
             CourseSemester.objects.filter(
@@ -56,6 +77,7 @@ class Command(BaseCommand):
         self._print_preview(
             profile=profile,
             semester=options["semester"],
+            source_period=scraped_history["period"],
             resolved=resolved,
             unmatched=unmatched,
             existing_codes=existing_codes,
@@ -85,9 +107,10 @@ class Command(BaseCommand):
             )
         )
 
-    def _scrape(self, siak_url):
+    def _scrape(self, history_url, login_timeout):
         try:
             from playwright.sync_api import Error as PlaywrightError
+            from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
             from playwright.sync_api import sync_playwright
         except ImportError as exc:
             raise CommandError(
@@ -101,12 +124,21 @@ class Command(BaseCommand):
                 context = browser.new_context()
                 try:
                     page = context.new_page()
-                    page.goto(siak_url, wait_until="domcontentloaded")
+                    page.goto(history_url, wait_until="domcontentloaded")
                     self.stdout.write(
-                        "Complete the SIAK challenge/login, open the active IRS "
-                        "page, then return here."
+                        "Complete the SIAK challenge/login in the browser. The "
+                        "latest academic-history period will be loaded automatically."
                     )
-                    input("Press Enter when the IRS table is visible... ")
+                    page.wait_for_function(
+                        AUTHENTICATED_MARKER,
+                        timeout=login_timeout * 1000,
+                    )
+                    page.goto(history_url, wait_until="domcontentloaded")
+                    page.wait_for_function(
+                        AUTHENTICATED_MARKER,
+                        timeout=30 * 1000,
+                    )
+                    page.wait_for_selector("table", state="attached", timeout=30 * 1000)
                     tables = []
                     for frame in list(page.frames):
                         try:
@@ -115,21 +147,31 @@ class Command(BaseCommand):
                             if frame.is_detached() or "Frame was detached" in str(exc):
                                 continue
                             raise
-                    return parse_irs_tables(tables)
+                    return parse_latest_history(tables)
                 finally:
                     context.close()
                     browser.close()
         except IRSParseError as exc:
             raise CommandError(str(exc)) from exc
+        except PlaywrightTimeoutError as exc:
+            raise CommandError(
+                "Timed out waiting for SIAK login or academic-history content."
+            ) from exc
         except PlaywrightError as exc:
             raise CommandError("SIAK browser session failed: {}".format(exc)) from exc
 
     def _print_preview(
-        self, profile, semester, resolved, unmatched, existing_codes
+        self,
+        profile,
+        semester,
+        source_period,
+        resolved,
+        unmatched,
+        existing_codes,
     ):
         self.stdout.write(
-            "Target: {} ({}) — semester {}".format(
-                profile.name, profile.username, semester
+            "Target: {} ({}) — calculator semester {} — SIAK period {}".format(
+                profile.name, profile.username, semester, source_period
             )
         )
         self.stdout.write("Recognized local courses:")

--- a/main/tests/test_siak_irs_import.py
+++ b/main/tests/test_siak_irs_import.py
@@ -1,0 +1,210 @@
+from io import StringIO
+from unittest.mock import patch
+
+from django.contrib.auth.models import User
+from django.core.management import call_command
+from django.test import TestCase
+
+from main.integrations.siak_irs import (
+    IRSParseError,
+    import_courses,
+    parse_irs_tables,
+    resolve_courses,
+)
+from main.models import (
+    Calculator,
+    Course,
+    CourseSemester,
+    Profile,
+    UserCumulativeGPA,
+    UserGPA,
+)
+
+
+class SIAKIRSParserTest(TestCase):
+    def test_parser_recognizes_irs_headers_and_deduplicates_codes(self):
+        courses = parse_irs_tables(
+            [
+                {
+                    "headers": ["No.", "Kode MK", "Nama Mata Kuliah", "SKS"],
+                    "rows": [
+                        ["1", " csge 601020 ", "Dasar Pemrograman", "4 SKS"],
+                        ["2", "CSGE601020", "Dasar Pemrograman", "4"],
+                        ["3", "UIGE600001", "MPKT", "5"],
+                    ],
+                }
+            ]
+        )
+
+        self.assertEqual(
+            courses,
+            [
+                {
+                    "code": "CSGE601020",
+                    "name": "Dasar Pemrograman",
+                    "credits": 4,
+                },
+                {"code": "UIGE600001", "name": "MPKT", "credits": 5},
+            ],
+        )
+
+    def test_parser_selects_largest_matching_table(self):
+        courses = parse_irs_tables(
+            [
+                {
+                    "headers": ["Course Code", "Course Name", "Credits"],
+                    "rows": [["OLD000001", "Old", "2"]],
+                },
+                {
+                    "headers": ["Kode", "Mata Kuliah", "Jumlah SKS"],
+                    "rows": [
+                        ["NEW000001", "New A", "3"],
+                        ["NEW000002", "New B", "2"],
+                    ],
+                },
+            ]
+        )
+
+        self.assertEqual(
+            [course["code"] for course in courses],
+            ["NEW000001", "NEW000002"],
+        )
+
+    def test_parser_ignores_larger_matching_table_without_valid_courses(self):
+        courses = parse_irs_tables(
+            [
+                {
+                    "headers": ["Kode MK", "Nama Mata Kuliah", "SKS"],
+                    "rows": [
+                        ["", "Summary row", ""],
+                        ["", "Another summary row", ""],
+                        ["", "Total", "5"],
+                    ],
+                },
+                {
+                    "headers": ["Kode", "Mata Kuliah", "Jumlah SKS"],
+                    "rows": [["VALID0001", "Valid Course", "3"]],
+                },
+            ]
+        )
+
+        self.assertEqual(
+            courses,
+            [{"code": "VALID0001", "name": "Valid Course", "credits": 3}],
+        )
+
+    def test_parser_rejects_unrecognized_page(self):
+        with self.assertRaises(IRSParseError):
+            parse_irs_tables(
+                [{"headers": ["Tanggal", "Keterangan"], "rows": [["1", "Test"]]}]
+            )
+
+
+class SIAKIRSImportTest(TestCase):
+    def setUp(self):
+        auth_user = User.objects.create_user(username="test-user")
+        self.profile = Profile.objects.create(
+            user=auth_user,
+            username="test-user",
+            name="Test User",
+            npm="2200000000",
+            faculty="Fasilkom",
+            study_program="Ilmu Komputer",
+            educational_program="S1 Reguler",
+            role="student",
+            org_code="01.00.12.01",
+        )
+        self.course = Course.objects.create(
+            code="CSGE601020",
+            curriculum="2024",
+            name="Dasar Pemrograman",
+            sks=4,
+            term=1,
+        )
+
+    def test_resolve_courses_reports_unknown_codes(self):
+        resolved, unmatched = resolve_courses(
+            [
+                {"code": "csge601020", "name": "Known", "credits": 4},
+                {"code": "UNKNOWN001", "name": "Unknown", "credits": 3},
+            ]
+        )
+
+        self.assertEqual(resolved, [self.course])
+        self.assertEqual([course["code"] for course in unmatched], ["UNKNOWN001"])
+
+    def test_import_creates_semester_calculator_and_updates_credits(self):
+        result = import_courses(self.profile, "1", [self.course])
+
+        semester = UserGPA.objects.get(given_semester="1")
+        cumulative = UserCumulativeGPA.objects.get(user=self.profile)
+        self.assertTrue(result["semester_created"])
+        self.assertEqual(result["inserted"], [self.course])
+        self.assertEqual(semester.total_sks, 4)
+        self.assertEqual(cumulative.total_sks, 4)
+        self.assertTrue(
+            CourseSemester.objects.filter(
+                semester=semester, course=self.course
+            ).exists()
+        )
+        self.assertTrue(
+            Calculator.objects.filter(user=self.profile, course=self.course).exists()
+        )
+
+    def test_import_skips_existing_course_without_replacing_calculator(self):
+        first_result = import_courses(self.profile, "1", [self.course])
+        calculator_id = CourseSemester.objects.get(course=self.course).calculator_id
+
+        second_result = import_courses(self.profile, "1", [self.course])
+
+        semester = UserGPA.objects.get(given_semester="1")
+        cumulative = UserCumulativeGPA.objects.get(user=self.profile)
+        self.assertEqual(second_result["inserted"], [])
+        self.assertEqual(second_result["duplicates"], [self.course])
+        self.assertEqual(semester.total_sks, 4)
+        self.assertEqual(cumulative.total_sks, 4)
+        self.assertEqual(
+            CourseSemester.objects.get(course=self.course).calculator_id,
+            calculator_id,
+        )
+        self.assertEqual(Calculator.objects.count(), 1)
+        self.assertEqual(first_result["inserted"], [self.course])
+
+    @patch(
+        "main.integrations.siak_irs.add_semester_gpa",
+        side_effect=RuntimeError("forced failure"),
+    )
+    def test_import_rolls_back_all_changes(self, _add_semester_gpa):
+        with self.assertRaises(RuntimeError):
+            import_courses(self.profile, "1", [self.course])
+
+        self.assertFalse(UserCumulativeGPA.objects.exists())
+        self.assertFalse(UserGPA.objects.exists())
+        self.assertFalse(Calculator.objects.exists())
+        self.assertFalse(CourseSemester.objects.exists())
+
+    @patch(
+        "main.management.commands.import_siak_irs.Command._scrape",
+        return_value=[
+            {
+                "code": "CSGE601020",
+                "name": "Dasar Pemrograman",
+                "credits": 4,
+            }
+        ],
+    )
+    def test_management_command_dry_run_does_not_write(self, _scrape):
+        stdout = StringIO()
+
+        call_command(
+            "import_siak_irs",
+            username=self.profile.username,
+            semester="1",
+            dry_run=True,
+            stdout=stdout,
+        )
+
+        self.assertIn("Dry run", stdout.getvalue())
+        self.assertFalse(UserCumulativeGPA.objects.exists())
+        self.assertFalse(UserGPA.objects.exists())
+        self.assertFalse(Calculator.objects.exists())

--- a/main/tests/test_siak_irs_import.py
+++ b/main/tests/test_siak_irs_import.py
@@ -1,15 +1,20 @@
 from io import StringIO
-from unittest.mock import patch
+from unittest.mock import MagicMock, call, patch
 
 from django.contrib.auth.models import User
-from django.core.management import call_command
+from django.core.management import call_command, CommandError
 from django.test import TestCase
+from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
 
 from main.integrations.siak_irs import (
     IRSParseError,
     import_courses,
-    parse_irs_tables,
+    parse_latest_history,
     resolve_courses,
+)
+from main.management.commands.import_siak_irs import (
+    AUTHENTICATED_MARKER,
+    Command,
 )
 from main.models import (
     Calculator,
@@ -22,22 +27,49 @@ from main.models import (
 
 
 class SIAKIRSParserTest(TestCase):
-    def test_parser_recognizes_irs_headers_and_deduplicates_codes(self):
-        courses = parse_irs_tables(
+    def test_parser_selects_latest_period_and_deduplicates_codes(self):
+        history = parse_latest_history(
             [
                 {
-                    "headers": ["No.", "Kode MK", "Nama Mata Kuliah", "SKS"],
+                    "headers": [
+                        "Periode Akademik",
+                        "Kode MK",
+                        "Nama Mata Kuliah",
+                        "SKS",
+                    ],
                     "rows": [
-                        ["1", " csge 601020 ", "Dasar Pemrograman", "4 SKS"],
-                        ["2", "CSGE601020", "Dasar Pemrograman", "4"],
-                        ["3", "UIGE600001", "MPKT", "5"],
+                        [
+                            "2024/2025 Ganjil",
+                            "OLD600001",
+                            "Old Course",
+                            "3",
+                        ],
+                        [
+                            "2024/2025 Genap",
+                            " csge 601020 ",
+                            "Dasar Pemrograman",
+                            "4 SKS",
+                        ],
+                        [
+                            "2024/2025 Genap",
+                            "CSGE601020",
+                            "Dasar Pemrograman",
+                            "4",
+                        ],
+                        [
+                            "2024/2025 Genap",
+                            "UIGE600001",
+                            "MPKT",
+                            "5",
+                        ],
                     ],
                 }
             ]
         )
 
+        self.assertEqual(history["period"], "2024/2025 Genap")
         self.assertEqual(
-            courses,
+            history["courses"],
             [
                 {
                     "code": "CSGE601020",
@@ -48,15 +80,17 @@ class SIAKIRSParserTest(TestCase):
             ],
         )
 
-    def test_parser_selects_largest_matching_table(self):
-        courses = parse_irs_tables(
+    def test_parser_selects_latest_non_empty_separate_period_table(self):
+        history = parse_latest_history(
             [
                 {
                     "headers": ["Course Code", "Course Name", "Credits"],
+                    "period_label": "2023/2024 Genap",
                     "rows": [["OLD000001", "Old", "2"]],
                 },
                 {
                     "headers": ["Kode", "Mata Kuliah", "Jumlah SKS"],
+                    "period_label": "2024/2025 Ganjil",
                     "rows": [
                         ["NEW000001", "New A", "3"],
                         ["NEW000002", "New B", "2"],
@@ -65,16 +99,50 @@ class SIAKIRSParserTest(TestCase):
             ]
         )
 
+        self.assertEqual(history["period"], "2024/2025 Ganjil")
         self.assertEqual(
-            [course["code"] for course in courses],
+            [course["code"] for course in history["courses"]],
             ["NEW000001", "NEW000002"],
         )
 
-    def test_parser_ignores_larger_matching_table_without_valid_courses(self):
-        courses = parse_irs_tables(
+    def test_parser_selects_latest_siak_separator_period(self):
+        history = parse_latest_history(
+            [
+                {
+                    "headers": [
+                        "No.",
+                        "Kode MK",
+                        "Kurikulum",
+                        "Nama MK",
+                        "Kelas",
+                        "SKS",
+                    ],
+                    "row_periods": [
+                        "Tahun Ajaran 2024/2025 Term 2",
+                        "Tahun Ajaran 2025/2026 Term 1",
+                        "Tahun Ajaran 2025/2026 Term 2",
+                    ],
+                    "rows": [
+                        ["1.", "OLD600001", "2024", "Old", "A", "3"],
+                        ["2.", "MID600001", "2024", "Middle", "A", "3"],
+                        ["3.", "NEW600001", "2024", "Newest", "A", "4"],
+                    ],
+                }
+            ]
+        )
+
+        self.assertEqual(history["period"], "Tahun Ajaran 2025/2026 Term 2")
+        self.assertEqual(
+            history["courses"],
+            [{"code": "NEW600001", "name": "Newest", "credits": 4}],
+        )
+
+    def test_parser_skips_newer_empty_period(self):
+        history = parse_latest_history(
             [
                 {
                     "headers": ["Kode MK", "Nama Mata Kuliah", "SKS"],
+                    "period_label": "2025/2026 Ganjil",
                     "rows": [
                         ["", "Summary row", ""],
                         ["", "Another summary row", ""],
@@ -83,21 +151,120 @@ class SIAKIRSParserTest(TestCase):
                 },
                 {
                     "headers": ["Kode", "Mata Kuliah", "Jumlah SKS"],
+                    "period_label": "2024/2025 Genap",
                     "rows": [["VALID0001", "Valid Course", "3"]],
                 },
             ]
         )
 
         self.assertEqual(
-            courses,
-            [{"code": "VALID0001", "name": "Valid Course", "credits": 3}],
+            history,
+            {
+                "period": "2024/2025 Genap",
+                "courses": [
+                    {"code": "VALID0001", "name": "Valid Course", "credits": 3}
+                ],
+            },
+        )
+
+    def test_parser_orders_short_term_after_even_term(self):
+        history = parse_latest_history(
+            [
+                {
+                    "headers": [
+                        "Term",
+                        "Course Code",
+                        "Course Name",
+                        "Credits",
+                    ],
+                    "rows": [
+                        ["2024/2025 Genap", "EVEN00001", "Even", "3"],
+                        ["2024/2025 Pendek", "SHORT0001", "Short", "2"],
+                    ],
+                }
+            ]
+        )
+
+        self.assertEqual(history["period"], "2024/2025 Pendek")
+        self.assertEqual(
+            history["courses"],
+            [{"code": "SHORT0001", "name": "Short", "credits": 2}],
+        )
+
+    def test_parser_rejects_course_table_without_period_metadata(self):
+        with self.assertRaisesMessage(
+            IRSParseError, "academic periods could not be recognized"
+        ):
+            parse_latest_history(
+                [
+                    {
+                        "headers": ["Kode", "Mata Kuliah", "SKS"],
+                        "rows": [["VALID0001", "Valid Course", "3"]],
+                    }
+                ]
+            )
+
+    def test_parser_rejects_unorderable_period(self):
+        with self.assertRaisesMessage(IRSParseError, "could not be ordered"):
+            parse_latest_history(
+                [
+                    {
+                        "headers": ["Kode", "Mata Kuliah", "SKS"],
+                        "period_label": "Periode terbaru",
+                        "rows": [["VALID0001", "Valid Course", "3"]],
+                    }
+                ]
+            )
+
+    def test_parser_supports_compact_numeric_period(self):
+        history = parse_latest_history(
+            [
+                {
+                    "headers": ["Periode", "Kode", "Mata Kuliah", "SKS"],
+                    "rows": [
+                        ["2024-1", "ODD000001", "Odd", "3"],
+                        ["2024-2", "EVEN00001", "Even", "3"],
+                    ],
+                }
+            ]
+        )
+
+        self.assertEqual(
+            history,
+            {
+                "period": "2024-2",
+                "courses": [
+                    {"code": "EVEN00001", "name": "Even", "credits": 3}
+                ],
+            },
         )
 
     def test_parser_rejects_unrecognized_page(self):
         with self.assertRaises(IRSParseError):
-            parse_irs_tables(
+            parse_latest_history(
                 [{"headers": ["Tanggal", "Keterangan"], "rows": [["1", "Test"]]}]
             )
+
+    def test_parser_deduplicates_courses_across_same_period_tables(self):
+        history = parse_latest_history(
+            [
+                {
+                    "headers": ["Kode", "Mata Kuliah", "SKS"],
+                    "period_label": "2024/2025 Genap",
+                    "rows": [["VALID0001", "Valid Course", "3"]],
+                },
+                {
+                    "headers": ["Kode", "Mata Kuliah", "SKS"],
+                    "period_label": "2024/2025 Genap",
+                    "rows": [["VALID0001", "Valid Course", "3"]],
+                },
+            ]
+        )
+
+        self.assertEqual(
+            history["courses"],
+            [{"code": "VALID0001", "name": "Valid Course", "credits": 3}],
+        )
 
 
 class SIAKIRSImportTest(TestCase):
@@ -185,13 +352,16 @@ class SIAKIRSImportTest(TestCase):
 
     @patch(
         "main.management.commands.import_siak_irs.Command._scrape",
-        return_value=[
-            {
-                "code": "CSGE601020",
-                "name": "Dasar Pemrograman",
-                "credits": 4,
-            }
-        ],
+        return_value={
+            "period": "2024/2025 Genap",
+            "courses": [
+                {
+                    "code": "CSGE601020",
+                    "name": "Dasar Pemrograman",
+                    "credits": 4,
+                }
+            ],
+        },
     )
     def test_management_command_dry_run_does_not_write(self, _scrape):
         stdout = StringIO()
@@ -205,6 +375,73 @@ class SIAKIRSImportTest(TestCase):
         )
 
         self.assertIn("Dry run", stdout.getvalue())
+        self.assertIn("2024/2025 Genap", stdout.getvalue())
         self.assertFalse(UserCumulativeGPA.objects.exists())
         self.assertFalse(UserGPA.objects.exists())
         self.assertFalse(Calculator.objects.exists())
+
+
+class SIAKIRSBrowserFlowTest(TestCase):
+    @patch(
+        "main.management.commands.import_siak_irs.parse_latest_history",
+        return_value={"period": "2024/2025 Genap", "courses": []},
+    )
+    @patch(
+        "main.management.commands.import_siak_irs.collect_page_tables",
+        return_value=[{"headers": [], "rows": []}],
+    )
+    @patch("playwright.sync_api.sync_playwright")
+    @patch("builtins.input", side_effect=AssertionError("input must not be called"))
+    def test_scrape_waits_for_login_and_navigates_to_history_automatically(
+        self,
+        _input,
+        sync_playwright,
+        _collect_page_tables,
+        _parse_latest_history,
+    ):
+        playwright = sync_playwright.return_value.__enter__.return_value
+        browser = playwright.chromium.launch.return_value
+        context = browser.new_context.return_value
+        page = context.new_page.return_value
+        frame = MagicMock()
+        page.frames = [frame]
+        history_url = "https://academic.ui.ac.id/main/Academic/HistoryByTerm"
+
+        result = Command()._scrape(history_url, 12)
+
+        self.assertEqual(result["period"], "2024/2025 Genap")
+        self.assertEqual(
+            page.goto.call_args_list,
+            [
+                call(history_url, wait_until="domcontentloaded"),
+                call(history_url, wait_until="domcontentloaded"),
+            ],
+        )
+        self.assertEqual(
+            page.wait_for_function.call_args_list,
+            [
+                call(AUTHENTICATED_MARKER, timeout=12000),
+                call(AUTHENTICATED_MARKER, timeout=30000),
+            ],
+        )
+        page.wait_for_selector.assert_called_once_with(
+            "table", state="attached", timeout=30000
+        )
+        context.close.assert_called_once()
+        browser.close.assert_called_once()
+
+    @patch("playwright.sync_api.sync_playwright")
+    def test_scrape_reports_login_timeout(self, sync_playwright):
+        playwright = sync_playwright.return_value.__enter__.return_value
+        page = (
+            playwright.chromium.launch.return_value
+            .new_context.return_value
+            .new_page.return_value
+        )
+        page.wait_for_function.side_effect = PlaywrightTimeoutError("timeout")
+
+        with self.assertRaisesMessage(CommandError, "Timed out waiting"):
+            Command()._scrape(
+                "https://academic.ui.ac.id/main/Academic/HistoryByTerm",
+                1,
+            )

--- a/requirements-siak.txt
+++ b/requirements-siak.txt
@@ -1,0 +1,2 @@
+playwright==1.44.0; python_version < "3.10"
+playwright==1.61.0; python_version >= "3.10"


### PR DESCRIPTION
## Thanks for your support to the project. Please check below mentioned points -

### Detailed description of changes

This PR adds a local proof-of-concept for importing a student's latest SIAK
academic-history period into the Teman Kuliah course calculator.

- Adds an optional Playwright setup for local use without changing the
  production Docker dependency set.
- Opens an isolated Chromium context so the user can complete the SIAK
  challenge and login directly. Credentials, cookies, page HTML, and browser
  storage are not persisted by Teman Kuliah.
- Automatically opens and returns to
  `https://academic.ui.ac.id/main/Academic/HistoryByTerm` after authentication;
  no terminal confirmation is required after login.
- Parses the nested SIAK history table and its `Tahun Ajaran ... Term ...`
  separator rows, then selects only the chronologically latest non-empty
  academic period.
- Extracts normalized course code, course name, and SKS, while failing closed
  if the table or period format cannot be recognized.
- Resolves scraped course codes against the local course catalog, reports
  unmatched codes, and skips courses already present in the destination
  semester.
- Imports calculators and course-semester records in one database transaction,
  including the existing semester and cumulative-SKS updates.
- Adds `--dry-run`, `--login-timeout`, and `--history-url` options.
  `--siak-url` remains available as a compatibility alias.
- Adds parser, browser-flow, timeout, rollback, duplicate, and dry-run test
  coverage, plus local usage documentation.

### Recommendations on how to test the changes

Install the optional local browser dependency:

```bash
pip install -r requirements-siak.txt
python -m playwright install chromium
```

Run a safe preview against an existing local profile and calculator semester:

```bash
python manage.py import_siak_irs \
  --username <teman-kuliah-username> \
  --semester <destination-semester> \
  --dry-run
```

Complete the SIAK challenge/login in the Chromium window. The command should
automatically navigate to HistoryByTerm and print only the latest period that
contains courses. Remove `--dry-run` to preview and confirm an actual local
database import.

Automated regression command used:

```bash
python manage.py test \
  main.tests.test_siak_irs_import \
  main.tests.test_cross_faculty_gpa \
  main.tests.test_grade_status \
  --settings=UlasKelas.test_settings
```

Result: 28 tests passed. A live dry-run also confirmed automatic login handoff
and selection of only the five courses in the latest non-empty SIAK period.
The production Docker image also built successfully, and Django's system check
inside that image reported no issues.

### Checklist for developer

- [x] The code builds clean without any errors or warnings
- [x] The code does not contain commented out code
- [x] The code does not log credentials, cookies, or scraped page contents
- [x] I have added unit test(s) to cover new code and successfully executed them
- [x] I have thoroughly tested the new code and adjacent calculator behavior

### Link to related issue(s)

N/A

### Screenshots or videos (before and after if appropriate)

N/A — the flow handles private academic data, so no authenticated SIAK
screenshots are attached.
