### PR TITLE
feat: expose course code in calculator serializer

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,25 @@ python manage.py sync_courses --org-code 01.00.12.01
 
 Run the all-program command weekly from the deployment scheduler. A failed
 program is reported at the end without preventing the remaining programs from
-being synchronized.
+being synchronized. Programs that have no SunJad catalog yet are reported as
+unavailable without making the command fail.
+
+Before the first sync after deploying course-code validation, audit invalid
+legacy courses with the dry-run cleanup command:
+
+```bash
+python manage.py cleanup_invalid_course_codes
+```
+
+After reviewing the output and taking a database backup, apply the cleanup:
+
+```bash
+python manage.py cleanup_invalid_course_codes --apply
+```
+
+The cleanup deactivates invalid catalog mappings. Invalid courses are deleted
+only when they have no review, bookmark, calculator, course-semester, or
+TanyaTeman references; referenced courses are retained for manual remediation.
 
 ### Import the latest SIAK academic-history period locally
 

--- a/courseUpdater/courseApi.py
+++ b/courseUpdater/courseApi.py
@@ -17,10 +17,36 @@ COURSE_TYPE_ALIASES = {
     "ELECTIVE": StudyProgramCourse.CourseType.ELECTIVE,
     "PILIHAN": StudyProgramCourse.CourseType.ELECTIVE,
 }
+INVALID_COURSE_CODE_SENTINELS = {"none", "null", "n/a"}
 
 
 class CourseSyncError(Exception):
     """Raised when a SunJad response cannot safely update the local catalog."""
+
+
+class CourseCatalogUnavailable(CourseSyncError):
+    """Raised when SunJad has no catalog for a configured study program."""
+
+
+def normalize_course_code(raw_code):
+    """Return a usable course code or reject known invalid SunJad values."""
+    if not isinstance(raw_code, str):
+        raise ValueError("course code is missing or is not a string")
+
+    code = raw_code.strip()
+    if not code:
+        raise ValueError("course code is empty")
+    if code.casefold() in INVALID_COURSE_CODE_SENTINELS:
+        raise ValueError("course code is an invalid sentinel: {!r}".format(raw_code))
+    return code
+
+
+def is_invalid_course_code(raw_code):
+    try:
+        normalize_course_code(raw_code)
+    except ValueError:
+        return True
+    return False
 
 
 def is_supported_educational_program(value):
@@ -75,6 +101,8 @@ def _fetch_courses_json(url):
     except (requests.RequestException, ValueError) as exc:
         raise CourseSyncError("Failed to fetch SunJad courses") from exc
 
+    if payload == {}:
+        raise CourseCatalogUnavailable("SunJad course catalog is unavailable")
     if not isinstance(payload, dict) or not isinstance(payload.get("courses"), list):
         raise CourseSyncError("Invalid SunJad courses response")
     return payload
@@ -136,9 +164,7 @@ def _apply_courses_payload(study_program, payload):
 
 
 def _upsert_course(course_json):
-    code = str(course_json["code"]).strip()
-    if not code:
-        raise ValueError("course code is empty")
+    code = normalize_course_code(course_json["code"])
 
     curriculum = str(course_json.get("curriculum") or "")
     course = Course.objects.filter(code=code).order_by("-curriculum", "id").first()

--- a/main/management/commands/cleanup_invalid_course_codes.py
+++ b/main/management/commands/cleanup_invalid_course_codes.py
@@ -1,0 +1,109 @@
+from django.core.management.base import BaseCommand
+from django.db import transaction
+
+from courseUpdater.courseApi import is_invalid_course_code
+from main.models import (
+    Bookmark,
+    Calculator,
+    Course,
+    CourseSemester,
+    Question,
+    StudyProgramCourse,
+)
+
+
+class Command(BaseCommand):
+    help = (
+        "Deactivate mappings for invalid course codes and delete invalid courses "
+        "that have no user-owned references. Runs as a dry-run by default."
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--apply",
+            action="store_true",
+            dest="apply_changes",
+            help="Apply the cleanup. Without this flag, only report planned changes.",
+        )
+
+    def handle(self, *args, **options):
+        apply_changes = options["apply_changes"]
+        candidates = [
+            course
+            for course in Course.objects.all().order_by("id")
+            if is_invalid_course_code(course.code)
+        ]
+
+        summary = {
+            "candidates": len(candidates),
+            "deleted": 0,
+            "retained": 0,
+            "mappings_deactivated": 0,
+        }
+
+        if apply_changes:
+            with transaction.atomic():
+                self._process_candidates(candidates, summary, apply_changes=True)
+        else:
+            self._process_candidates(candidates, summary, apply_changes=False)
+
+        mode = "APPLIED" if apply_changes else "DRY RUN"
+        mapping_summary = (
+            "deactivated" if apply_changes else "would be deactivated"
+        )
+        self.stdout.write(
+            "{}: {candidates} candidate(s), {deleted} deleted, "
+            "{retained} retained, {mappings_deactivated} active mapping(s) "
+            "{}".format(mode, mapping_summary, **summary)
+        )
+        if not apply_changes:
+            self.stdout.write("Run again with --apply to perform this cleanup.")
+
+    def _process_candidates(self, candidates, summary, apply_changes):
+        for course in candidates:
+            course_id = course.id
+            course_code = course.code
+            reference_counts = self._get_user_reference_counts(course)
+            total_references = sum(reference_counts.values())
+            active_mappings = StudyProgramCourse.objects.filter(
+                course=course,
+                is_active=True,
+            )
+            mapping_count = active_mappings.count()
+
+            if total_references:
+                action = "retain and deactivate mappings"
+                summary["retained"] += 1
+                summary["mappings_deactivated"] += mapping_count
+                if apply_changes:
+                    active_mappings.update(is_active=False)
+            else:
+                action = "delete"
+                summary["deleted"] += 1
+                if apply_changes:
+                    course.delete()
+
+            references = ", ".join(
+                "{}={}".format(name, count)
+                for name, count in reference_counts.items()
+                if count
+            ) or "none"
+            self.stdout.write(
+                "Course id={} code={!r}: {}; active_mappings={}; references={}".format(
+                    course_id,
+                    course_code,
+                    action,
+                    mapping_count,
+                    references,
+                )
+            )
+
+    @staticmethod
+    def _get_user_reference_counts(course):
+        return {
+            "reviews": course.reviews.count(),
+            "bookmarks": Bookmark.objects.filter(course=course).count(),
+            "calculators": Calculator.objects.filter(course=course).count(),
+            "course_semesters": CourseSemester.objects.filter(course=course).count(),
+            "questions": Question.objects.filter(course=course).count(),
+        }

--- a/main/management/commands/sync_courses.py
+++ b/main/management/commands/sync_courses.py
@@ -3,6 +3,7 @@ import logging
 from django.core.management.base import BaseCommand, CommandError
 
 from courseUpdater.courseApi import (
+    CourseCatalogUnavailable,
     CourseSyncError,
     get_supported_program_configs,
     update_courses,
@@ -35,6 +36,7 @@ class Command(BaseCommand):
             if sync_all
             else [org_code]
         )
+        unavailable = []
         failed = []
         for current_org_code in org_codes:
             try:
@@ -47,6 +49,15 @@ class Command(BaseCommand):
                         )
                     )
                 )
+            except CourseCatalogUnavailable as exc:
+                unavailable.append(current_org_code)
+                logger.warning(
+                    "Course catalog unavailable for org_code=%s",
+                    current_org_code,
+                )
+                self.stderr.write(
+                    self.style.WARNING("{}: {}".format(current_org_code, exc))
+                )
             except CourseSyncError as exc:
                 failed.append(current_org_code)
                 logger.exception(
@@ -55,6 +66,15 @@ class Command(BaseCommand):
                 self.stderr.write(
                     self.style.ERROR("{}: {}".format(current_org_code, exc))
                 )
+
+        if unavailable:
+            self.stderr.write(
+                self.style.WARNING(
+                    "Course catalog unavailable for {} program(s): {}".format(
+                        len(unavailable), ", ".join(unavailable)
+                    )
+                )
+            )
 
         if failed:
             raise CommandError(

--- a/main/serializers.py
+++ b/main/serializers.py
@@ -1,7 +1,7 @@
 from live_config.views import get_config
 from main.utils import get_profile_term
 from rest_framework import serializers
-from django.db.models import Avg
+from django.db.models import Avg, Prefetch
 
 from .models import (
     Answer,
@@ -17,6 +17,7 @@ from .models import (
     UserGPA,
     CourseSemester,
     ScoreSubcomponent,
+    StudyProgramCourse,
     get_attachment_presigned_url,
 )
 
@@ -38,6 +39,30 @@ from .models import (
 #     class Meta:
 #         model = Course
 #         fields = ['name', 'category']
+
+
+def serialize_course_faculties(course):
+    mappings = getattr(course, "active_study_program_courses", None)
+    if mappings is None:
+        mappings = course.study_program_courses.filter(
+            is_active=True, study_program__is_supported=True
+        ).select_related("study_program")
+
+    faculties = {}
+    for mapping in mappings:
+        study_program = mapping.study_program
+        org_code_parts = study_program.org_code.split(".")
+        faculty_id = (
+            org_code_parts[2]
+            if len(org_code_parts) >= 3
+            else study_program.org_code
+        )
+        faculties.setdefault(
+            faculty_id,
+            {"id": faculty_id, "name": study_program.faculty},
+        )
+
+    return sorted(faculties.values(), key=lambda faculty: faculty["name"].casefold())
 
 
 class CourseSerializer(serializers.ModelSerializer):
@@ -74,29 +99,7 @@ class CourseSerializer(serializers.ModelSerializer):
         return getattr(obj, "annotated_course_type", "UNKNOWN")
 
     def get_faculties(self, obj):
-        mappings = getattr(obj, "active_study_program_courses", None)
-        if mappings is None:
-            mappings = obj.study_program_courses.filter(
-                is_active=True, study_program__is_supported=True
-            ).select_related("study_program")
-
-        faculties = {}
-        for mapping in mappings:
-            study_program = mapping.study_program
-            org_code_parts = study_program.org_code.split(".")
-            faculty_id = (
-                org_code_parts[2]
-                if len(org_code_parts) >= 3
-                else study_program.org_code
-            )
-            faculties.setdefault(
-                faculty_id,
-                {"id": faculty_id, "name": study_program.faculty},
-            )
-
-        return sorted(
-            faculties.values(), key=lambda faculty: faculty["name"].casefold()
-        )
+        return serialize_course_faculties(obj)
 
     def get_review_count(self, obj):
         return (
@@ -419,6 +422,16 @@ class CalculatorSerializer(serializers.ModelSerializer):
         return None
 
 
+class CourseSemesterCalculatorSerializer(CalculatorSerializer):
+    faculties = serializers.SerializerMethodField("get_faculties")
+
+    class Meta(CalculatorSerializer.Meta):
+        fields = CalculatorSerializer.Meta.fields + ("faculties",)
+
+    def get_faculties(self, obj):
+        return serialize_course_faculties(obj.course)
+
+
 class ScoreComponentSerializer(serializers.ModelSerializer):
     calculator_id = serializers.SerializerMethodField("get_calculator_id")
     score = serializers.SerializerMethodField("get_score")
@@ -489,15 +502,27 @@ class SemesterWithCourseSerializer(serializers.ModelSerializer):
         fields = ["semester", "courses_calculator"]
 
     def get_courses_calculator(self, obj):
-        list_courses = CourseSemester.objects.filter(semester=obj)
-        list_courses = [course_semester.course for course_semester in list_courses]
-        list_calculator = [
-            CourseSemester.objects.filter(semester=obj, course=course)
-            .first()
-            .calculator
-            for course in list_courses
+        course_semesters = (
+            CourseSemester.objects.filter(semester=obj)
+            .select_related(
+                "calculator",
+                "calculator__course",
+                "calculator__user",
+            )
+            .prefetch_related(
+                Prefetch(
+                    "calculator__course__study_program_courses",
+                    queryset=StudyProgramCourse.objects.filter(
+                        is_active=True, study_program__is_supported=True
+                    ).select_related("study_program"),
+                    to_attr="active_study_program_courses",
+                )
+            )
+        )
+        calculators = [
+            course_semester.calculator for course_semester in course_semesters
         ]
-        return CalculatorSerializer(list_calculator, many=True).data
+        return CourseSemesterCalculatorSerializer(calculators, many=True).data
 
     def get_semester(self, obj):
         return UserGPASerializer(obj).data

--- a/main/serializers.py
+++ b/main/serializers.py
@@ -379,6 +379,8 @@ class CalculatorSerializer(serializers.ModelSerializer):
     course_id = serializers.SerializerMethodField("get_course_id")
     course_name = serializers.SerializerMethodField("get_course_name")
     course_sks = serializers.SerializerMethodField("get_course_sks")
+    course_code = serializers.SerializerMethodField("get_course_code")
+    course_code_desc = serializers.SerializerMethodField("get_course_code_desc")
 
     class Meta:
         model = Calculator
@@ -388,6 +390,8 @@ class CalculatorSerializer(serializers.ModelSerializer):
             "course_id",
             "course_name",
             "course_sks",
+            "course_code",
+            "course_code_desc",
             "total_score",
             "total_percentage",
         )
@@ -403,6 +407,16 @@ class CalculatorSerializer(serializers.ModelSerializer):
 
     def get_course_sks(self, obj):
         return obj.course.sks
+
+    def get_course_code(self, obj):
+        return obj.course.code
+
+    def get_course_code_desc(self, obj):
+        course_prefixes = get_config("course_prefixes")
+        code = obj.course.code[:4]
+        if code in course_prefixes:
+            return course_prefixes[code]
+        return None
 
 
 class ScoreComponentSerializer(serializers.ModelSerializer):

--- a/main/tests/test_calculator_serializer.py
+++ b/main/tests/test_calculator_serializer.py
@@ -1,0 +1,39 @@
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from django.test import SimpleTestCase
+
+from main.serializers import CalculatorSerializer
+
+
+class CalculatorSerializerTest(SimpleTestCase):
+    def setUp(self):
+        self.calculator = SimpleNamespace(
+            id=1,
+            user=SimpleNamespace(username="student"),
+            course=SimpleNamespace(
+                id=2,
+                name="Dasar-Dasar Pemrograman",
+                sks=4,
+                code="CSGE601020",
+            ),
+            total_score=85,
+            total_percentage=100,
+        )
+
+    @patch(
+        "main.serializers.get_config",
+        return_value={"CSGE": "Computer Science - General"},
+    )
+    def test_includes_course_code_and_description(self, get_config):
+        data = CalculatorSerializer(self.calculator).data
+
+        self.assertEqual(data["course_code"], "CSGE601020")
+        self.assertEqual(data["course_code_desc"], "Computer Science - General")
+        get_config.assert_called_once_with("course_prefixes")
+
+    @patch("main.serializers.get_config", return_value={})
+    def test_course_code_description_is_null_for_unknown_prefix(self, _get_config):
+        data = CalculatorSerializer(self.calculator).data
+
+        self.assertIsNone(data["course_code_desc"])

--- a/main/tests/test_calculator_serializer.py
+++ b/main/tests/test_calculator_serializer.py
@@ -30,6 +30,7 @@ class CalculatorSerializerTest(SimpleTestCase):
 
         self.assertEqual(data["course_code"], "CSGE601020")
         self.assertEqual(data["course_code_desc"], "Computer Science - General")
+        self.assertNotIn("faculties", data)
         get_config.assert_called_once_with("course_prefixes")
 
     @patch("main.serializers.get_config", return_value={})

--- a/main/tests/test_cleanup_invalid_course_codes.py
+++ b/main/tests/test_cleanup_invalid_course_codes.py
@@ -1,0 +1,93 @@
+from io import StringIO
+
+from django.contrib.auth.models import User
+from django.core.management import call_command
+from django.test import TestCase
+
+from main.models import (
+    Calculator,
+    Course,
+    Profile,
+    StudyProgram,
+    StudyProgramCourse,
+)
+
+
+class CleanupInvalidCourseCodesTest(TestCase):
+    def setUp(self):
+        auth_user = User.objects.create_user(username="test-user")
+        self.profile = Profile.objects.create(
+            user=auth_user,
+            username="test-user",
+            name="Test User",
+            npm="2200000000",
+            faculty="Fakultas A",
+            study_program="Program A",
+            educational_program="S1 Reguler",
+            role="student",
+            org_code="01",
+        )
+        self.program = StudyProgram.objects.create(
+            org_code="01",
+            faculty="Fakultas A",
+            study_program="Program A",
+            educational_program="S1 Reguler",
+        )
+
+    def create_course(self, code, name):
+        return Course.objects.create(
+            code=code,
+            curriculum="2024",
+            name=name,
+            sks=3,
+            term=1,
+        )
+
+    def create_mapping(self, course):
+        return StudyProgramCourse.objects.create(
+            study_program=self.program,
+            course=course,
+            program_term=1,
+        )
+
+    def test_dry_run_does_not_modify_invalid_courses(self):
+        course = self.create_course("None", "Polluted Course")
+        mapping = self.create_mapping(course)
+        stdout = StringIO()
+
+        call_command("cleanup_invalid_course_codes", stdout=stdout)
+
+        self.assertTrue(Course.objects.filter(pk=course.pk).exists())
+        mapping.refresh_from_db()
+        self.assertTrue(mapping.is_active)
+        self.assertIn("DRY RUN: 1 candidate(s)", stdout.getvalue())
+
+    def test_apply_deletes_unreferenced_invalid_course(self):
+        course = self.create_course("N/A", "Unreferenced Course")
+        self.create_mapping(course)
+
+        call_command("cleanup_invalid_course_codes", "--apply", stdout=StringIO())
+
+        self.assertFalse(Course.objects.filter(pk=course.pk).exists())
+
+    def test_apply_retains_referenced_course_and_deactivates_mapping(self):
+        course = self.create_course("null", "Referenced Course")
+        mapping = self.create_mapping(course)
+        calculator = Calculator.objects.create(user=self.profile, course=course)
+
+        call_command("cleanup_invalid_course_codes", "--apply", stdout=StringIO())
+
+        self.assertTrue(Course.objects.filter(pk=course.pk).exists())
+        self.assertTrue(Calculator.objects.filter(pk=calculator.pk).exists())
+        mapping.refresh_from_db()
+        self.assertFalse(mapping.is_active)
+
+    def test_apply_does_not_touch_valid_course(self):
+        course = self.create_course("CSGE601012", "Valid Course")
+        mapping = self.create_mapping(course)
+
+        call_command("cleanup_invalid_course_codes", "--apply", stdout=StringIO())
+
+        self.assertTrue(Course.objects.filter(pk=course.pk).exists())
+        mapping.refresh_from_db()
+        self.assertTrue(mapping.is_active)

--- a/main/tests/test_course_sync.py
+++ b/main/tests/test_course_sync.py
@@ -1,9 +1,18 @@
+from io import StringIO
 from unittest.mock import patch
 
+from django.contrib.auth.models import User
+from django.core.management import call_command, CommandError
 from django.test import TestCase
+from rest_framework.test import APITestCase
 
-from courseUpdater.courseApi import CourseSyncError, _apply_courses_payload
-from main.models import Course, StudyProgram, StudyProgramCourse
+from courseUpdater.courseApi import (
+    CourseCatalogUnavailable,
+    CourseSyncError,
+    _apply_courses_payload,
+    _fetch_courses_json,
+)
+from main.models import Course, Profile, StudyProgram, StudyProgramCourse
 
 
 class CourseSyncTest(TestCase):
@@ -120,3 +129,112 @@ class CourseSyncTest(TestCase):
         self.assertTrue(mapping.is_active)
         self.assertEqual(result["skipped_courses"], 1)
         self.assertEqual(result["inactive_courses"], 0)
+
+    @patch("courseUpdater.courseApi.get_config", return_value={})
+    def test_sync_rejects_invalid_course_code_sentinels(self, _get_config):
+        result = _apply_courses_payload(
+            self.program,
+            {
+                "courses": [
+                    {"code": None},
+                    {"code": ""},
+                    {"code": "   "},
+                    {"code": "None"},
+                    {"code": "NULL"},
+                    {"code": "n/a"},
+                    {"name": "Missing code"},
+                    {
+                        "code": " CUSTOM-1 ",
+                        "curriculum": "2024",
+                        "credit": "3",
+                        "name": "Valid custom code",
+                        "term": "1",
+                    },
+                ]
+            },
+        )
+
+        self.assertEqual(result["active_courses"], 1)
+        self.assertEqual(result["skipped_courses"], 7)
+        self.assertEqual(
+            list(Course.objects.values_list("code", flat=True)),
+            ["CUSTOM-1"],
+        )
+
+    @patch("courseUpdater.courseApi.requests.get")
+    def test_empty_object_response_means_catalog_unavailable(self, mock_get):
+        mock_get.return_value.json.return_value = {}
+
+        with self.assertRaises(CourseCatalogUnavailable):
+            _fetch_courses_json("https://sunjad.test/catalog")
+
+        mock_get.return_value.raise_for_status.assert_called_once_with()
+
+
+class SyncCoursesCommandTest(TestCase):
+    @patch(
+        "main.management.commands.sync_courses.get_supported_program_configs",
+        return_value={"01": {}, "02": {}},
+    )
+    @patch("main.management.commands.sync_courses.update_courses")
+    def test_unavailable_catalog_does_not_fail_command(
+        self, mock_update, _mock_configs
+    ):
+        mock_update.side_effect = [
+            CourseCatalogUnavailable("catalog unavailable"),
+            {
+                "org_code": "02",
+                "active_courses": 1,
+                "inactive_courses": 0,
+                "skipped_courses": 0,
+            },
+        ]
+        stderr = StringIO()
+
+        call_command("sync_courses", "--all", stderr=stderr)
+
+        self.assertIn(
+            "Course catalog unavailable for 1 program(s): 01",
+            stderr.getvalue(),
+        )
+
+    @patch(
+        "main.management.commands.sync_courses.get_supported_program_configs",
+        return_value={"01": {}},
+    )
+    @patch("main.management.commands.sync_courses.update_courses")
+    def test_technical_failure_still_fails_command(self, mock_update, _mock_configs):
+        mock_update.side_effect = CourseSyncError("invalid response")
+
+        with self.assertRaisesMessage(CommandError, "Synchronization failed for 1"):
+            call_command("sync_courses", "--all", stderr=StringIO())
+
+
+class RefreshCoursesTest(APITestCase):
+    def setUp(self):
+        self.auth_user = User.objects.create_user(username="test-user")
+        Profile.objects.create(
+            user=self.auth_user,
+            username="test-user",
+            name="Test User",
+            npm="2200000000",
+            faculty="Fakultas A",
+            study_program="Program A",
+            educational_program="S1 Reguler",
+            role="student",
+            org_code="01",
+        )
+        self.client.force_authenticate(self.auth_user)
+
+    @patch(
+        "main.views.courseApi.update_courses",
+        side_effect=CourseCatalogUnavailable("SunJad course catalog is unavailable"),
+    )
+    def test_unavailable_catalog_returns_conflict(self, _mock_update):
+        response = self.client.post("/update-course/")
+
+        self.assertEqual(response.status_code, 409)
+        self.assertEqual(
+            response.data["error"]["code"],
+            "COURSE_CATALOG_UNAVAILABLE",
+        )

--- a/main/tests/test_cross_faculty_gpa.py
+++ b/main/tests/test_cross_faculty_gpa.py
@@ -1,15 +1,20 @@
+from unittest.mock import patch
+
 from django.contrib.auth.models import User
 from django.utils import timezone
 from rest_framework.test import APITestCase
 
 from main.models import (
+    Calculator,
     Course,
     CourseSemester,
     Profile,
     StudyProgram,
     StudyProgramCourse,
+    UserCumulativeGPA,
     UserGPA,
 )
+from main.serializers import SemesterWithCourseSerializer
 
 
 class CrossFacultyGPATest(APITestCase):
@@ -101,3 +106,50 @@ class CrossFacultyGPATest(APITestCase):
 
         self.assertEqual(response.status_code, 201)
         self.assertFalse(CourseSemester.objects.exists())
+
+    @patch("main.serializers.get_config", return_value={})
+    def test_course_semester_returns_course_faculties(self, _get_config):
+        course = self.create_catalog()
+        unmapped_course = Course.objects.create(
+            code="ZZ000001",
+            curriculum="2024",
+            name="Unmapped Course",
+            sks=2,
+            term=1,
+        )
+        cumulative_gpa = UserCumulativeGPA.objects.create(user=self.profile)
+        semester = UserGPA.objects.create(
+            userCumulativeGPA=cumulative_gpa,
+            given_semester="1",
+        )
+        calculator = Calculator.objects.create(user=self.profile, course=course)
+        unmapped_calculator = Calculator.objects.create(
+            user=self.profile,
+            course=unmapped_course,
+        )
+        CourseSemester.objects.create(
+            semester=semester,
+            course=course,
+            calculator=calculator,
+        )
+        CourseSemester.objects.create(
+            semester=semester,
+            course=unmapped_course,
+            calculator=unmapped_calculator,
+        )
+
+        with self.assertNumQueries(2):
+            SemesterWithCourseSerializer(semester).data
+
+        response = self.client.get("/api/v1/course-semester?given_semester=1")
+
+        self.assertEqual(response.status_code, 200)
+        courses = {
+            item["course_id"]: item
+            for item in response.data["data"]["courses_calculator"]
+        }
+        self.assertEqual(
+            courses[course.id]["faculties"],
+            [{"id": "01", "name": "Fakultas A"}],
+        )
+        self.assertEqual(courses[unmapped_course.id]["faculties"], [])

--- a/main/views.py
+++ b/main/views.py
@@ -37,6 +37,17 @@ def refresh_courses(request):
     profile = request.user.profile_set.get()
     try:
         sync_result = courseApi.update_courses(profile.org_code)
+    except courseApi.CourseCatalogUnavailable as exc:
+        logger.warning("Course catalog unavailable for org_code=%s", profile.org_code)
+        return Response(
+            {
+                "error": {
+                    "code": "COURSE_CATALOG_UNAVAILABLE",
+                    "message": str(exc),
+                }
+            },
+            status=status.HTTP_409_CONFLICT,
+        )
     except courseApi.CourseSyncError as exc:
         logger.exception("Course update failed for org_code=%s", profile.org_code)
         return Response({"message": str(exc)}, status=status.HTTP_502_BAD_GATEWAY)


### PR DESCRIPTION
## Thanks for your support to the project. Please check below mentioned points

### Detailed description of changes

- Expose `course_code` and `course_code_desc` in calculator responses.
- Resolve course-code descriptions from the `course_prefixes` live configuration and return `null` for unknown prefixes.
- Expose deduplicated, sorted `faculties` in `/api/v1/course-semester` without changing the shared `/calculator` response contract.
- Prefetch course, user, and active study-program mappings so semester-card serialization does not introduce N+1 queries.
- Reject invalid SunJad course codes before creating `Course` or `StudyProgramCourse` records: missing/null values, empty or whitespace-only strings, and the `None`, `null`, and `N/A` sentinels.
- Treat an empty SunJad object (`{}`) as `COURSE_CATALOG_UNAVAILABLE`: batch synchronization continues without a nonzero exit, while network and malformed-schema failures remain fatal after all programs are processed.
- Return HTTP 409 with `COURSE_CATALOG_UNAVAILABLE` from `/update-course/` when the selected program has no SunJad catalog.
- Add `cleanup_invalid_course_codes`, which runs as a dry-run by default. With `--apply`, it deactivates invalid mappings, deletes only unreferenced invalid courses, and preserves courses linked to user data for manual remediation.
- Document the safe staging cleanup and synchronization sequence.

This change does not add or modify database schema migrations.

### Recommendations on how to test the changes

Run the focused regression suite:

```bash
python manage.py test \
  main.tests.test_calculator_serializer \
  main.tests.test_cross_faculty_gpa \
  main.tests.test_majors \
  main.tests.test_course_sync \
  main.tests.test_cleanup_invalid_course_codes
```

Expected result: 24 tests pass.

Inspect the cleanup without changing data:

```bash
python manage.py cleanup_invalid_course_codes
```

For staging rollout, take a database backup, review the dry-run output, then run:

```bash
python manage.py cleanup_invalid_course_codes --apply
python manage.py sync_courses --all
```

Expected API additions include:

```json
{
  "course_code": "CSGE601020",
  "course_code_desc": "Computer Science - General",
  "faculties": [
    {"id": "12", "name": "ILMU KOMPUTER"}
  ]
}
```

The full local `main.tests` run executes 66 tests: 64 pass and two pre-existing modules fail during collection because they still import the removed `Curriculum` model and `CurriculumSerializer`. Those collection errors are unrelated to this PR.

### Checklist for developer

- [x] Targeted serializer, catalog, synchronization, cleanup, and endpoint tests pass
- [x] Invalid SunJad values cannot create new polluted course mappings
- [x] Cleanup defaults to dry-run and protects user-owned references
- [x] No schema migration is required
- [x] Diff and syntax checks pass
- [x] Staging rollout steps are documented

### Link to related issue(s)

N/A

### Screenshots or videos (before and after if appropriate)

N/A — backend API, synchronization, and management-command changes only.
