### PR TITLE
Fix Selenium certifi dependency conflict

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 APScheduler==3.8.0
 asgiref==3.2.10
 autopep8==1.5.4
-certifi==2020.11.8
+certifi==2024.7.4
 chardet==3.0.4
 dj-database-url==0.5.0
 Django==3.1.2


### PR DESCRIPTION
## Detailed description of changes

Fixes the Docker image build failure caused by an incompatible `certifi` pin.

- Updates `certifi` from `2020.11.8` to `2024.7.4`.
- Keeps an exact version pin to preserve reproducible builds.
- Satisfies Selenium 4.27.1, which requires `certifi>=2021.10.8`.
- Leaves Selenium and all other project dependencies unchanged.

## Root cause

The Dockerfile runs `pip install -r requirements.txt` using Python 3.8. Pip could not resolve both `certifi==2020.11.8` and Selenium 4.27.1's newer certifi requirement.

## Verification performed

- [x] Python 3.8 dependency resolution succeeds for Selenium, certifi, requests, and urllib3.
- [x] Full Docker image build succeeds through `RUN pip install -r requirements.txt` and image export.
- [x] 24 focused SLCM API, parser, import, and browser-flow tests pass.
- [x] `git diff --check` passes.

## Files changed

- `requirements.txt`
