### PR TITLE
feat: add course category filtering

### DIFF
--- a/courseUpdater/courseApi.py
+++ b/courseUpdater/courseApi.py
@@ -21,6 +21,16 @@ COURSE_TYPE_ALIASES = {
     "ELECTIVE": StudyProgramCourse.CourseType.ELECTIVE,
     "PILIHAN": StudyProgramCourse.CourseType.ELECTIVE,
 }
+CATEGORY_ALIASES = {
+    "KELAS INTERNAL": StudyProgramCourse.Category.INTERNAL,
+    "INTERNAL": StudyProgramCourse.Category.INTERNAL,
+    "KELAS BERSAMA": StudyProgramCourse.Category.SHARED,
+    "BERSAMA": StudyProgramCourse.Category.SHARED,
+    "SHARED": StudyProgramCourse.Category.SHARED,
+    "KELAS EKSTERNAL": StudyProgramCourse.Category.EXTERNAL,
+    "EKSTERNAL": StudyProgramCourse.Category.EXTERNAL,
+    "EXTERNAL": StudyProgramCourse.Category.EXTERNAL,
+}
 INVALID_COURSE_CODE_SENTINELS = {"none", "null", "n/a"}
 
 
@@ -178,6 +188,7 @@ def _apply_courses_payload(study_program, payload):
                     "program_term": int(course_json["term"]),
                     "curriculum": str(course_json.get("curriculum") or ""),
                     "course_type": _resolve_course_type(course_json),
+                    "category": _resolve_category(course_json),
                     "is_active": True,
                 },
             )
@@ -230,7 +241,6 @@ def _resolve_course_type(course_json):
     raw_type = (
         course_json.get("course_type")
         or course_json.get("type")
-        or course_json.get("category")
     )
     if raw_type:
         normalized_type = str(raw_type).strip().upper()
@@ -253,6 +263,15 @@ def _resolve_course_type(course_json):
         if "pilihan" in normalized_description or "peminatan" in normalized_description:
             return StudyProgramCourse.CourseType.ELECTIVE
     return StudyProgramCourse.CourseType.UNKNOWN
+
+
+def _resolve_category(course_json):
+    raw_category = course_json.get("category")
+    if not raw_category:
+        return StudyProgramCourse.Category.UNKNOWN
+    return CATEGORY_ALIASES.get(
+        str(raw_category).strip().upper(), StudyProgramCourse.Category.UNKNOWN
+    )
 
 
 # Backwards-compatible helpers retained for callers/tests that imported them.

--- a/main/migrations/0029_studyprogramcourse_category.py
+++ b/main/migrations/0029_studyprogramcourse_category.py
@@ -1,0 +1,29 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [("main", "0028_slcmautofillsession")]
+
+    operations = [
+        migrations.AddField(
+            model_name="studyprogramcourse",
+            name="category",
+            field=models.CharField(
+                choices=[
+                    ("INTERNAL", "Kelas Internal"),
+                    ("SHARED", "Kelas Bersama"),
+                    ("EXTERNAL", "Kelas Eksternal"),
+                    ("UNKNOWN", "Belum diketahui"),
+                ],
+                default="UNKNOWN",
+                max_length=16,
+            ),
+        ),
+        migrations.AddIndex(
+            model_name="studyprogramcourse",
+            index=models.Index(
+                fields=["study_program", "is_active", "category"],
+                name="main_studyp_study_p_71c1d0_idx",
+            ),
+        ),
+    ]

--- a/main/models.py
+++ b/main/models.py
@@ -68,6 +68,12 @@ class StudyProgramCourse(models.Model):
         ELECTIVE = "ELECTIVE", "Pilihan"
         UNKNOWN = "UNKNOWN", "Belum diketahui"
 
+    class Category(models.TextChoices):
+        INTERNAL = "INTERNAL", "Kelas Internal"
+        SHARED = "SHARED", "Kelas Bersama"
+        EXTERNAL = "EXTERNAL", "Kelas Eksternal"
+        UNKNOWN = "UNKNOWN", "Belum diketahui"
+
     study_program = models.ForeignKey(
         StudyProgram, on_delete=models.CASCADE, related_name="course_mappings"
     )
@@ -78,6 +84,9 @@ class StudyProgramCourse(models.Model):
     curriculum = models.CharField(max_length=20, blank=True)
     course_type = models.CharField(
         max_length=16, choices=CourseType.choices, default=CourseType.UNKNOWN
+    )
+    category = models.CharField(
+        max_length=16, choices=Category.choices, default=Category.UNKNOWN
     )
     is_active = models.BooleanField(default=True)
 
@@ -90,6 +99,7 @@ class StudyProgramCourse(models.Model):
         ]
         indexes = [
             models.Index(fields=["study_program", "is_active", "program_term"]),
+            models.Index(fields=["study_program", "is_active", "category"]),
             models.Index(fields=["course_type"]),
         ]
 

--- a/main/serializers.py
+++ b/main/serializers.py
@@ -83,6 +83,7 @@ class CourseSerializer(serializers.ModelSerializer):
     rating_average = serializers.SerializerMethodField("get_rating_average")
     program_term = serializers.SerializerMethodField("get_program_term")
     course_type = serializers.SerializerMethodField("get_course_type")
+    category = serializers.SerializerMethodField("get_category")
     faculties = serializers.SerializerMethodField("get_faculties")
 
     def get_code_desc(self, obj):
@@ -97,6 +98,9 @@ class CourseSerializer(serializers.ModelSerializer):
 
     def get_course_type(self, obj):
         return getattr(obj, "annotated_course_type", "UNKNOWN")
+
+    def get_category(self, obj):
+        return getattr(obj, "annotated_category", "UNKNOWN")
 
     def get_faculties(self, obj):
         return serialize_course_faculties(obj)
@@ -199,6 +203,7 @@ class CourseSerializer(serializers.ModelSerializer):
                 "rating_average",
                 "program_term",
                 "course_type",
+                "category",
                 "faculties",
             ]
         )

--- a/main/tests/test_course_sync.py
+++ b/main/tests/test_course_sync.py
@@ -42,6 +42,7 @@ class CourseSyncTest(TestCase):
                         "name": "Course A",
                         "term": "2",
                         "prerequisite": None,
+                        "category": "Kelas Internal",
                     },
                     {
                         "code": "XX000001",
@@ -61,9 +62,47 @@ class CourseSyncTest(TestCase):
         unknown = StudyProgramCourse.objects.get(course__code="XX000001")
         self.assertEqual(mandatory.program_term, 2)
         self.assertEqual(mandatory.course_type, "MANDATORY")
+        self.assertEqual(mandatory.category, "INTERNAL")
         self.assertEqual(unknown.course_type, "UNKNOWN")
+        self.assertEqual(unknown.category, "UNKNOWN")
         self.program.refresh_from_db()
         self.assertIsNotNone(self.program.last_synced_at)
+
+    @patch("courseUpdater.courseApi.get_config", return_value={})
+    def test_sync_normalizes_categories_without_treating_them_as_course_types(
+        self, _get_config
+    ):
+        categories = [
+            ("Kelas Internal", StudyProgramCourse.Category.INTERNAL),
+            ("Kelas Bersama", StudyProgramCourse.Category.SHARED),
+            ("Kelas Eksternal", StudyProgramCourse.Category.EXTERNAL),
+            ("", StudyProgramCourse.Category.UNKNOWN),
+            ("Kategori Baru", StudyProgramCourse.Category.UNKNOWN),
+        ]
+        payload = {
+            "courses": [
+                {
+                    "code": "CAT{:05d}".format(index),
+                    "curriculum": "2024",
+                    "credit": 3,
+                    "name": "Category {}".format(index),
+                    "term": 1,
+                    "category": raw_category,
+                }
+                for index, (raw_category, _expected) in enumerate(categories)
+            ]
+        }
+
+        _apply_courses_payload(self.program, payload)
+
+        mappings = {
+            mapping.course.code: mapping
+            for mapping in StudyProgramCourse.objects.select_related("course")
+        }
+        for index, (_raw_category, expected) in enumerate(categories):
+            mapping = mappings["CAT{:05d}".format(index)]
+            self.assertEqual(mapping.category, expected)
+            self.assertEqual(mapping.course_type, StudyProgramCourse.CourseType.UNKNOWN)
 
     @patch("courseUpdater.courseApi.get_config", return_value={})
     def test_successful_sync_marks_missing_relations_inactive(self, _get_config):

--- a/main/tests/test_majors.py
+++ b/main/tests/test_majors.py
@@ -173,16 +173,19 @@ class MajorsEndpointTest(APITestCase):
             course=matching,
             program_term=2,
             course_type=StudyProgramCourse.CourseType.MANDATORY,
+            category=StudyProgramCourse.Category.INTERNAL,
         )
         StudyProgramCourse.objects.create(
             study_program=program,
             course=other,
             program_term=1,
             course_type=StudyProgramCourse.CourseType.ELECTIVE,
+            category=StudyProgramCourse.Category.SHARED,
         )
 
         response = self.client.get(
-            "/api/courses/?major=01&term=2&course_type=MANDATORY&show_all=true"
+            "/api/courses/?major=01&term=2&course_type=MANDATORY"
+            "&category=INTERNAL&show_all=true"
         )
 
         self.assertEqual(response.status_code, 200)
@@ -190,9 +193,51 @@ class MajorsEndpointTest(APITestCase):
         self.assertEqual([course["code"] for course in courses], ["PZ000001"])
         self.assertEqual(courses[0]["program_term"], 2)
         self.assertEqual(courses[0]["course_type"], "MANDATORY")
+        self.assertEqual(courses[0]["category"], "INTERNAL")
         self.assertEqual(
             courses[0]["faculties"], [{"id": "01", "name": "Fakultas A"}]
         )
+
+        multiple = self.client.get(
+            "/api/courses/?major=01&category=INTERNAL,SHARED&show_all=true"
+        )
+        self.assertEqual(
+            {course["category"] for course in multiple.data["data"]["courses"]},
+            {"INTERNAL", "SHARED"},
+        )
+
+        invalid = self.client.get(
+            "/api/courses/?major=01&category=INVALID&show_all=true"
+        )
+        self.assertEqual(invalid.data["data"]["courses"], [])
+
+    @patch("main.views_course.get_config", return_value=PROGRAM_CONFIG)
+    def test_cross_program_category_filter_uses_active_mappings(self, _get_config):
+        program = StudyProgram.objects.create(
+            org_code="01",
+            faculty="Fakultas A",
+            study_program="Program Z",
+            educational_program="S1 Reguler",
+        )
+        course = Course.objects.create(
+            code="SHARED01", curriculum="2024", name="Shared", sks=3, term=1
+        )
+        StudyProgramCourse.objects.create(
+            study_program=program,
+            course=course,
+            program_term=1,
+            category=StudyProgramCourse.Category.SHARED,
+        )
+
+        response = self.client.get(
+            "/api/courses/?show_all=true&category=SHARED"
+        )
+
+        self.assertEqual(
+            [item["code"] for item in response.data["data"]["courses"]],
+            ["SHARED01"],
+        )
+        self.assertEqual(response.data["data"]["courses"][0]["category"], "UNKNOWN")
 
     @patch("main.views_course.get_config", return_value=PROGRAM_CONFIG)
     def test_unknown_or_unsupported_major_returns_bad_request(self, _get_config):

--- a/main/tests/test_majors.py
+++ b/main/tests/test_majors.py
@@ -212,6 +212,75 @@ class MajorsEndpointTest(APITestCase):
         self.assertEqual(invalid.data["data"]["courses"], [])
 
     @patch("main.views_course.get_config", return_value=PROGRAM_CONFIG)
+    def test_major_defaults_to_internal_shared_and_owned_unknown(self, _get_config):
+        program = StudyProgram.objects.create(
+            org_code="01",
+            faculty="Fakultas A",
+            study_program="Program Z",
+            educational_program="S1 Reguler",
+        )
+        fixtures = [
+            ("Internal", StudyProgramCourse.Category.INTERNAL, "02-2024"),
+            ("Shared", StudyProgramCourse.Category.SHARED, "02-2024"),
+            ("Owned unknown", StudyProgramCourse.Category.UNKNOWN, "01-2024"),
+            ("External", StudyProgramCourse.Category.EXTERNAL, "02-2024"),
+            ("Foreign unknown", StudyProgramCourse.Category.UNKNOWN, "02-2024"),
+            ("Missing curriculum", StudyProgramCourse.Category.UNKNOWN, ""),
+        ]
+        for index, (name, category, curriculum) in enumerate(fixtures):
+            course = Course.objects.create(
+                code="OWN{:05d}".format(index),
+                curriculum=curriculum,
+                name=name,
+                sks=3,
+                term=1,
+            )
+            StudyProgramCourse.objects.create(
+                study_program=program,
+                course=course,
+                program_term=1,
+                curriculum=curriculum,
+                category=category,
+            )
+
+        response = self.client.get("/api/courses/?major=01&show_all=true")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            [course["name"] for course in response.data["data"]["courses"]],
+            ["Internal", "Owned unknown", "Shared"],
+        )
+
+    @patch("main.views_course.get_config", return_value=PROGRAM_CONFIG)
+    def test_explicit_category_overrides_default_major_ownership(self, _get_config):
+        program = StudyProgram.objects.create(
+            org_code="01",
+            faculty="Fakultas A",
+            study_program="Program Z",
+            educational_program="S1 Reguler",
+        )
+        external = Course.objects.create(
+            code="EXTERNAL", curriculum="02-2024", name="External", sks=3, term=1
+        )
+        StudyProgramCourse.objects.create(
+            study_program=program,
+            course=external,
+            program_term=1,
+            curriculum="02-2024",
+            category=StudyProgramCourse.Category.EXTERNAL,
+        )
+
+        response = self.client.get(
+            "/api/courses/?major=01&category=EXTERNAL&show_all=true"
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            [course["code"] for course in response.data["data"]["courses"]],
+            ["EXTERNAL"],
+        )
+
+    @patch("main.views_course.get_config", return_value=PROGRAM_CONFIG)
     def test_cross_program_category_filter_uses_active_mappings(self, _get_config):
         program = StudyProgram.objects.create(
             org_code="01",

--- a/main/views_course.py
+++ b/main/views_course.py
@@ -138,6 +138,7 @@ class CourseViewSet(AutoPrefetchViewSetMixin, viewsets.ReadOnlyModelViewSet):
             ).annotate(
                 program_term=F("study_program_courses__program_term"),
                 annotated_course_type=F("study_program_courses__course_type"),
+                annotated_category=F("study_program_courses__category"),
             )
         else:
             # show_all is still a catalog view: courses that disappeared from
@@ -291,6 +292,26 @@ def filter_course(request, courses, program_filtered=False):
             courses = courses.filter(
                 study_program_courses__is_active=True,
                 study_program_courses__course_type__in=requested_types,
+            )
+
+    categories = request.query_params.get("category")
+    if categories is not None:
+        valid_categories = {choice[0] for choice in StudyProgramCourse.Category.choices}
+        requested_categories = {
+            value.strip().upper()
+            for value in categories.split(",")
+            if value.strip()
+        }
+        if not requested_categories or not requested_categories.issubset(
+            valid_categories
+        ):
+            return courses.none()
+        if program_filtered:
+            courses = courses.filter(annotated_category__in=requested_categories)
+        else:
+            courses = courses.filter(
+                study_program_courses__is_active=True,
+                study_program_courses__category__in=requested_categories,
             )
 
     return courses

--- a/main/views_course.py
+++ b/main/views_course.py
@@ -139,7 +139,31 @@ class CourseViewSet(AutoPrefetchViewSetMixin, viewsets.ReadOnlyModelViewSet):
                 program_term=F("study_program_courses__program_term"),
                 annotated_course_type=F("study_program_courses__course_type"),
                 annotated_category=F("study_program_courses__category"),
+                annotated_program_curriculum=F(
+                    "study_program_courses__curriculum"
+                ),
             )
+
+            # A SunJad all_courses catalog also contains external courses. When
+            # callers do not request a category explicitly, keep the major
+            # catalog focused on internal/shared courses. Older records whose
+            # category has not been backfilled can only be considered internal
+            # when their program-specific curriculum identifies this major.
+            if request.query_params.get("category") is None:
+                courses = courses.filter(
+                    Q(
+                        annotated_category__in=[
+                            StudyProgramCourse.Category.INTERNAL,
+                            StudyProgramCourse.Category.SHARED,
+                        ]
+                    )
+                    | Q(
+                        annotated_category=StudyProgramCourse.Category.UNKNOWN,
+                        annotated_program_curriculum__startswith=(
+                            "{}-".format(effective_major)
+                        ),
+                    )
+                )
         else:
             # show_all is still a catalog view: courses that disappeared from
             # every supported SunJad catalog remain stored only for history.


### PR DESCRIPTION
## Thanks for your support to the project. Please check below mentioned points -

### Detailed description of changes

- Adds program-specific course categories: `INTERNAL`, `SHARED`, `EXTERNAL`, and `UNKNOWN`.
- Separates SunJad class category from the existing mandatory/elective `course_type` domain.
- Normalizes `Kelas Internal`, `Kelas Bersama`, and `Kelas Eksternal` from SunJad during course synchronization.
- Adds `category` to course responses and supports explicit filtering with `category=INTERNAL,SHARED`.
- Makes every request with `major=<kd_org>` default to internal and shared courses instead of exposing the full SunJad `all_courses` catalog.
- Includes stale `UNKNOWN` mappings only when their program-specific curriculum starts with the requested kd_org, providing a safe internal-course fallback.
- Keeps an explicit category query as an override, so clients can intentionally request external courses.
- Adds a database migration and composite index for program/category filtering.

The existing Mobdev request remains valid:

```http
GET /api/v1/courses/?major=06.00.12.01&show_all=true&page=1
```

`show_all=true` continues to mean all semesters; it does not disable major ownership filtering.

After deployment, run:

```bash
python manage.py migrate
python manage.py sync_courses --all
```

The full sync refreshes category values for existing program-course mappings.

### Recommendations on how to test the changes

1. Run `python manage.py migrate`.
2. Run `python manage.py sync_courses --org-code 06.00.12.01`.
3. Request `/api/v1/courses/?major=06.00.12.01&show_all=true&page=1` and verify internal/shared courses are returned while external and unrelated UNKNOWN courses are excluded.
4. Verify UNKNOWN mappings whose curriculum begins with `06.00.12.01-` remain visible as the stale-data fallback.
5. Request `category=EXTERNAL` and verify the explicit filter overrides the default ownership scope.
6. Verify requests without `show_all=true` still apply the profile semester behavior.
7. Run `python manage.py test main.tests.test_course_sync main.tests.test_majors`.

Verification performed locally:

- 25 focused sync and endpoint tests passed.
- Migration consistency check reported no changes.
- Full `main` suite previously ran 86 tests: 84 passed; two pre-existing import errors remain in legacy tests that reference removed `Curriculum` and `CurriculumSerializer` symbols.

### Checklist for developer

- [x] The code builds clean without any errors or warnings
- [x] The code does not contain commented out code
- [x] The code does not log anything to console
- [x] I have added unit test(s) to cover new code and successfully executed ran it
- [x] I have thoroughly tested the new code and any adjacent features it may affect

### Link to related issue(s)

N/A

### Screenshots or videos (before and after if appropriate)

Not applicable; this change affects the backend API and course synchronization.