### PR TITLE
fix: force HTTPS for SLCM popup URL

### DIFF
--- a/main/tests/test_slcm_autofill_api.py
+++ b/main/tests/test_slcm_autofill_api.py
@@ -38,6 +38,7 @@ class SLCMAutofillAPITest(APITestCase):
         )
         self.assertEqual(result.status_code, 201)
         self.assertEqual(result.data["data"]["status"], "waiting_login")
+        self.assertTrue(result.data["data"]["popup_url"].startswith("https://"))
         self.assertIn("/api/slcm-autofill/popup/", result.data["data"]["popup_url"])
         duplicate = self.client.post(
             "/api/slcm-autofill/sessions", {"given_semester": "2"}, format="json"

--- a/main/views_slcm_autofill.py
+++ b/main/views_slcm_autofill.py
@@ -108,7 +108,9 @@ def slcm_autofill_sessions(request):
             expires_at=timezone.now() + timedelta(seconds=settings.SLCM_AUTOFILL_TIMEOUT_SECONDS),
         )
         popup_path = reverse("v1:slcm-autofill-popup", kwargs={"token": token})
-        session.popup_url = request.build_absolute_uri(popup_path)
+        session.popup_url = request.build_absolute_uri(popup_path).replace(
+            "http://", "https://", 1
+        )
         session.save(update_fields=["popup_url", "updated_at"])
         transaction.on_commit(lambda: start_scraper(session.id))
     return response(data=_serialize(session, include_popup=True), status=status.HTTP_201_CREATED)


### PR DESCRIPTION
## Summary
- force generated SLCM popup URLs to use HTTPS
- assert the popup URL scheme in the SLCM autofill API test

## Verification
- python3 -m compileall passed
- Django test suite was not run locally because Django is not installed in the execution environment