### PR TITLE
fix: improve mobile noVNC viewport

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,8 +203,11 @@ status is `ready`, and finish with
 `POST /api/slcm-autofill/sessions/{session_id}/confirm`. Cancel an unfinished
 session with `DELETE /api/slcm-autofill/sessions/{session_id}`.
 
-The remote browser defaults to a touch-enabled `430x932` viewport. Override it
-with `SLCM_BROWSER_SCREEN_WIDTH` and `SLCM_BROWSER_SCREEN_HEIGHT` when needed.
+The remote browser defaults to a touch-enabled `430x932` kiosk viewport, so
+Chromium's tabs and address bar do not consume the mobile login area. noVNC
+scales that fixed portrait framebuffer to the available frontend view, including
+when the on-screen keyboard changes its height. Override the framebuffer with
+`SLCM_BROWSER_SCREEN_WIDTH` and `SLCM_BROWSER_SCREEN_HEIGHT` when needed.
 The frontend should keep polling after opening the popup and close its popup or
 browser view when the session becomes `ready`, `failed`, `expired`, or
 `cancelled`; the course preview remains in the regular application UI.

--- a/main/integrations/slcm_autofill.py
+++ b/main/integrations/slcm_autofill.py
@@ -95,10 +95,13 @@ def mobile_screen_size():
 
 
 def configure_mobile_chrome(options):
-    """Configure Chrome for a phone-sized, touch-enabled SLCM login."""
+    """Configure Chrome as a phone-sized, touch-enabled login surface."""
     width, height = mobile_screen_size()
     options.add_argument("--window-size={},{}".format(width, height))
     options.add_argument("--force-device-scale-factor=1")
+    # noVNC is the browser chrome for this flow. Hide Chromium's own tabs and
+    # address bar so the limited portrait framebuffer is reserved for SLCM.
+    options.add_argument("--kiosk")
     options.add_experimental_option(
         "mobileEmulation",
         {
@@ -115,7 +118,7 @@ def configure_mobile_chrome(options):
 
 
 def position_mobile_window(driver):
-    """Fill the portrait virtual desktop instead of leaving a small window."""
+    """Fill the portrait virtual desktop with the kiosk browser."""
     width, height = mobile_screen_size()
     driver.set_window_rect(x=0, y=0, width=width, height=height)
 

--- a/main/tests/test_slcm_autofill_api.py
+++ b/main/tests/test_slcm_autofill_api.py
@@ -107,7 +107,7 @@ class SLCMAutofillAPITest(APITestCase):
         self.assertEqual(opened.status_code, 302)
         self.assertEqual(
             opened["Location"],
-            "https://browser.example.test/?autoconnect=1&resize=remote&show_dot=true",
+            "https://browser.example.test/?autoconnect=1&resize=scale&show_dot=true",
         )
         self.assertEqual(self.client.get(url).status_code, 404)
 
@@ -119,6 +119,7 @@ class SLCMAutofillAPITest(APITestCase):
         self.assertIs(configured, options)
         options.add_argument.assert_any_call("--window-size=430,932")
         options.add_argument.assert_any_call("--force-device-scale-factor=1")
+        options.add_argument.assert_any_call("--kiosk")
         options.add_experimental_option.assert_called_once_with(
             "mobileEmulation",
             {

--- a/main/views_slcm_autofill.py
+++ b/main/views_slcm_autofill.py
@@ -190,6 +190,6 @@ def slcm_autofill_popup(request, token):
         session.save(update_fields=["popup_opened_at", "updated_at"])
     target = (
         settings.SLCM_BROWSER_PUBLIC_URL.rstrip("/")
-        + "/?autoconnect=1&resize=remote&show_dot=true"
+        + "/?autoconnect=1&resize=scale&show_dot=true"
     )
     return redirect(target)


### PR DESCRIPTION
## Summary
- run remote Chromium in kiosk mode to reserve the portrait framebuffer for SLCM
- scale the fixed mobile framebuffer to the available noVNC/WebView area
- update autofill coverage and deployment documentation

## Testing
- `python3 -m py_compile main/integrations/slcm_autofill.py main/views_slcm_autofill.py main/tests/test_slcm_autofill_api.py`
- `git diff --check`

## Notes
- Django tests could not run locally because Django is not installed
- Docker-based verification was unavailable because the Docker socket is not accessible